### PR TITLE
ci: route release bumps through pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,11 @@ jobs:
 
       - name: Check issue reference
         run: |
+          if [[ "${{ github.head_ref }}" == chore/release-v* ]]; then
+            echo "✓ Release PRs do not require an issue reference"
+            exit 0
+          fi
+
           PR_TITLE="$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")"
           PR_BODY="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
 

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version_type:
-        description: 'Version bump type'
+        description: Version bump type
         required: true
-        default: 'patch'
+        default: patch
         type: choice
         options:
           - patch
@@ -14,13 +14,15 @@ on:
           - major
 
 jobs:
-  release:
+  create-release-pr:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
@@ -34,12 +36,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: '9'
+          version: "9"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -70,27 +72,32 @@ jobs:
         id: bump
         run: |
           NEW_VERSION=$(python scripts/bump_version.py ${{ github.event.inputs.version_type }})
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch_name=chore/release-v$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Bumped to $NEW_VERSION"
 
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.bump.outputs.branch_name }}"
           git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
           git commit -m "chore(release): bump version to ${{ steps.bump.outputs.new_version }}"
-          git push
+          git push --force-with-lease origin "${{ steps.bump.outputs.branch_name }}"
 
-      - name: Create tag
-        run: |
-          git tag "v${{ steps.bump.outputs.new_version }}"
-          git push origin "v${{ steps.bump.outputs.new_version }}"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ steps.bump.outputs.new_version }}
-          name: Release v${{ steps.bump.outputs.new_version }}
-          generate_release_notes: true
+      - name: Create release PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "${{ steps.bump.outputs.branch_name }}" --state open --json number --jq '.[0].number // ""')
+
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Release PR already exists: #$EXISTING_PR"
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch_name }}" \
+            --title "chore(release): bump version to ${{ steps.bump.outputs.new_version }}" \
+            --body "Manual ${{ github.event.inputs.version_type }} release version bump. Merge this PR to publish v${{ steps.bump.outputs.new_version }}."

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -3,9 +3,13 @@ name: Release Patch
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
 
 jobs:
   check-unreleased:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
@@ -17,21 +21,23 @@ jobs:
       - name: Check for unreleased changes
         id: check
         run: |
-          LAST_COMMIT_MSG=$(git log -1 --pretty=%B)
-          if echo "$LAST_COMMIT_MSG" | grep -q "chore(release):"; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "Last commit is a release, skipping"
+          LAST_COMMIT_MSG="$(git log -1 --pretty=%B)"
+
+          if echo "$LAST_COMMIT_MSG" | grep -qE 'chore\(release\):|chore/release-v'; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "Last commit is release-related, skipping release PR creation"
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "Unreleased changes detected"
           fi
 
-  release:
+  create-release-pr:
     needs: check-unreleased
-    if: needs.check-unreleased.outputs.has_changes == 'true'
+    if: github.event_name == 'push' && needs.check-unreleased.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,12 +54,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: '9'
+          version: "9"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -84,27 +90,68 @@ jobs:
         id: bump
         run: |
           NEW_VERSION=$(python scripts/bump_version.py patch)
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch_name=chore/release-v$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Bumped to $NEW_VERSION"
 
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.bump.outputs.branch_name }}"
           git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
           git commit -m "chore(release): bump version to ${{ steps.bump.outputs.new_version }}"
-          git push
+          git push --force-with-lease origin "${{ steps.bump.outputs.branch_name }}"
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "${{ steps.bump.outputs.branch_name }}" --state open --json number --jq '.[0].number // ""')
+
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Release PR already exists: #$EXISTING_PR"
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch_name }}" \
+            --title "chore(release): bump version to ${{ steps.bump.outputs.new_version }}" \
+            --body "Automated patch release version bump. Merge this PR to publish v${{ steps.bump.outputs.new_version }}."
+
+  publish-release:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/release-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(python -c 'import json; print(json.load(open("package.json"))["version"])')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
         run: |
-          git tag "v${{ steps.bump.outputs.new_version }}"
-          git push origin "v${{ steps.bump.outputs.new_version }}"
+          if git ls-remote --tags origin "v${{ steps.version.outputs.version }}" | grep -q "v${{ steps.version.outputs.version }}"; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists"
+            exit 0
+          fi
+
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.bump.outputs.new_version }}
-          name: Release v${{ steps.bump.outputs.new_version }}
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **User description**
Closes #14

## Summary
- Change automatic patch releases to create a release-bump PR instead of pushing directly to protected main.
- Change manual releases to create release-bump PRs for patch, minor, and major bumps.
- Publish the tag and GitHub Release only after a chore/release-v* PR is merged.
- Exempt chore/release-v* branches from the PR issue-reference check.

## Testing
- pnpm exec prettier --check .github/workflows/pull-request.yml .github/workflows/release-patch.yml .github/workflows/release-manual.yml
- Parsed touched workflow YAML with PyYAML


___

### **PR Type**
Enhancement


___

### **Description**
- Updates release workflows to create Pull Requests instead of pushing directly to the protected `main` branch.

- Modifies the manual release workflow to generate a version-bump PR for patch, minor, or major updates.

- Configures the automatic patch workflow to trigger on PR merges and handle tag/release creation.

- Exempts release-related PR branches from the mandatory issue reference check in CI.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Release Process"
  A["Push to main / Manual Trigger"] -- "Create Branch" --> B["chore/release-v*"]
  B -- "Open PR" --> C["Release Pull Request"]
  C -- "Merge PR" --> D["Publish Tag & GitHub Release"]
  end
  E["CI Check"] -- "Exempt" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pull-request.yml</strong><dd><code>Exempt release PRs from issue check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pull-request.yml

<ul><li>Added a condition to skip the issue reference check if the branch name <br>starts with <code>chore/release-v*</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AgentIron/AgentIron/pull/15/files#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-manual.yml</strong><dd><code>Convert manual release to PR-based flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-manual.yml

<ul><li>Replaced direct tag and release creation with a step that creates a <br>new branch and opens a Pull Request.<br> <li> Added <code>pull-requests: write</code> permissions and logic to check for existing <br>open release PRs.<br> <li> Updated checkout to explicitly use the <code>main</code> branch.</ul>


</details>


  </td>
  <td><a href="https://github.com/AgentIron/AgentIron/pull/15/files#diff-1428a216a0d8251f725011d3bbaa176f65416bf34e788f30c976e5d1e7b95fff">+26/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-patch.yml</strong><dd><code>Refactor patch release for branch protection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-patch.yml

<ul><li>Split the workflow into <code>create-release-pr</code> and <code>publish-release</code> jobs.<br> <li> <code>create-release-pr</code> now triggers on push to <code>main</code> and opens a PR.<br> <li> <code>publish-release</code> triggers when a release PR is merged, handling tagging <br>and GitHub Release creation.<br> <li> Improved commit message filtering to avoid recursive triggers.</ul>


</details>


  </td>
  <td><a href="https://github.com/AgentIron/AgentIron/pull/15/files#diff-df301738e68565dd9ccdf94c1a6c46c7cd3f131f03b25ec58d3c0b45bd607835">+62/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

