### PR TITLE
feat(skills): replace inline diagnostics with batched toasts and compact summary

### DIFF
--- a/src/components/settings/SkillsSettings.tsx
+++ b/src/components/settings/SkillsSettings.tsx
@@ -1,7 +1,8 @@
 import { createSignal, For, Show, type Component } from "solid-js";
-import { TbOutlineRefresh, TbOutlineFolderPlus, TbOutlineX, TbOutlineCheck, TbOutlineAlertCircle } from "solid-icons/tb";
+import { TbOutlineRefresh, TbOutlineFolderPlus, TbOutlineX, TbOutlineCheck } from "solid-icons/tb";
 import { useSettings } from "@context/SettingsContext";
 import { useAgent } from "@context/AgentContext";
+import { useNotification } from "@context/NotificationContext";
 import {
   refreshSkillCatalog,
   listAvailableSkills,
@@ -23,18 +24,13 @@ interface SkillItem {
   active: boolean;
 }
 
-interface Diagnostic {
-  level: string;
-  message: string;
-  skillName?: string;
-}
-
 export const SkillsSettings: Component = () => {
   const { settings, updateSkillSettings, addSkillDir, removeSkillDir } = useSettings();
   const { state: agentState } = useAgent();
+  const { notify } = useNotification();
 
   const [skills, setSkills] = createSignal<SkillItem[]>([]);
-  const [diagnostics, setDiagnostics] = createSignal<Diagnostic[]>([]);
+  const [lastRefreshSummary, setLastRefreshSummary] = createSignal<{ warnings: number; errors: number } | null>(null);
   const [loading, setLoading] = createSignal(false);
   const [newDir, setNewDir] = createSignal("");
 
@@ -50,7 +46,28 @@ export const SkillsSettings: Component = () => {
         listAvailableSkills(tid),
         listActiveSkills(tid),
       ]);
-      setDiagnostics(diag);
+      const errors = diag.filter((d) => d.level === "Error").length;
+      const warnings = diag.filter((d) => d.level === "Warning").length;
+      setLastRefreshSummary({ warnings, errors });
+
+      if (errors > 0) {
+        notify(
+          "error",
+          `Skill refresh completed with ${errors} error${errors === 1 ? "" : "s"}`,
+          {
+            message:
+              warnings > 0
+                ? `and ${warnings} warning${warnings === 1 ? "" : "s"}`
+                : undefined,
+          },
+        );
+      } else if (warnings > 0) {
+        notify(
+          "warning",
+          `Skill refresh completed with ${warnings} warning${warnings === 1 ? "" : "s"}`,
+        );
+      }
+
       setSkills(
         available.map((s) => ({
           ...s,
@@ -59,6 +76,7 @@ export const SkillsSettings: Component = () => {
       );
     } catch (err) {
       console.error("Failed to load skills:", err);
+      notify("error", "Failed to refresh skills", { message: String(err) });
     } finally {
       setLoading(false);
     }
@@ -167,24 +185,20 @@ export const SkillsSettings: Component = () => {
           <p class="text-sm text-text-tertiary">Open a chat tab to view and manage skills.</p>
         </Show>
 
-        <Show when={diagnostics().length > 0}>
-          <div class="space-y-1">
-            <For each={diagnostics()}>
-              {(d) => (
-                <div class={`flex items-start gap-1.5 rounded-md px-3 py-1.5 text-xs ${
-                  d.level === "Error" ? "bg-error/10 text-error" :
-                  d.level === "Warning" ? "bg-warning/10 text-warning" :
-                  "bg-bg-elevated text-text-tertiary"
-                }`}>
-                  <TbOutlineAlertCircle size={13} class="mt-0.5 flex-shrink-0" />
-                  <div>
-                    <span class="font-medium">{d.level}:</span>{" "}
-                    {d.message}
-                    {d.skillName && <span class="text-text-tertiary"> ({d.skillName})</span>}
-                  </div>
-                </div>
-              )}
-            </For>
+        <Show when={lastRefreshSummary()}>
+          <div
+            class={`text-xs rounded-md px-3 py-1.5 ${
+              (lastRefreshSummary()?.errors ?? 0) > 0
+                ? "bg-error/10 text-error"
+                : (lastRefreshSummary()?.warnings ?? 0) > 0
+                  ? "bg-warning/10 text-warning"
+                  : "bg-success/10 text-success"
+            }`}
+          >
+            <span class="font-medium">Refresh completed{" "}</span>
+            {(lastRefreshSummary()!.errors > 0 || lastRefreshSummary()!.warnings > 0)
+              ? `with ${lastRefreshSummary()!.errors > 0 ? `${lastRefreshSummary()!.errors} error${lastRefreshSummary()!.errors === 1 ? "" : "s"}` : ""}${lastRefreshSummary()!.errors > 0 && lastRefreshSummary()!.warnings > 0 ? " and " : ""}${lastRefreshSummary()!.warnings > 0 ? `${lastRefreshSummary()!.warnings} warning${lastRefreshSummary()!.warnings === 1 ? "" : "s"}` : ""}`
+              : "successfully"}
           </div>
         </Show>
 


### PR DESCRIPTION
### **User description**
## Summary

- Replaces the large inline diagnostics list in the skill catalog settings with a lightweight summary line showing error/warning counts.
- Surfaces skill refresh warnings and errors through the app-wide toast notification system (`useNotification`) instead of rendering all messages inline.
- Adds batched toasts: one toast for errors, one for warnings, rather than one per diagnostic item.
- Shows an error toast on refresh failure (catch path) so critical failures remain actionable.

Closes #25

## Acceptance Criteria

- [x] Refreshing the skill catalog no longer creates a large inline diagnostics list in the settings panel.
- [x] Non-critical refresh warnings are surfaced through toasts or a batched toast summary.
- [x] Users can still tell whether refresh succeeded cleanly or succeeded with warnings.
- [x] Critical failures remain actionable and visible.

## Verification

- `pnpm lint` — passed
- `pnpm build` — passed


___

### **PR Type**
Enhancement


___

### **Description**
- Replaces inline diagnostic logs with batched toast notifications.

- Adds a compact refresh summary in the settings panel.

- Implements toast notifications for skill refresh failures.

- Reduces UI clutter by removing detailed diagnostic lists.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph UI ["SkillsSettings UI"]
    RefreshBtn["Refresh Button"]
    Summary["Compact Summary"]
  end
  subgraph Logic ["Refresh Logic"]
    RefreshCall["refreshSkillCatalog()"]
    Calc["Calculate Counts"]
    Notify["useNotification (Toasts)"]
  end
  RefreshBtn -- "Click" --> RefreshCall
  RefreshCall -- "Diagnostics" --> Calc
  Calc -- "Batched Messages" --> Notify
  Calc -- "Update State" --> Summary
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SkillsSettings.tsx</strong><dd><code>Refactor skill refresh diagnostics to use toasts and summary</code></dd></summary>
<hr>

src/components/settings/SkillsSettings.tsx

<ul><li>Replaced the <code>diagnostics</code> state with <code>lastRefreshSummary</code> to track error <br>and warning counts instead of full message objects.<br> <li> Integrated <code>useNotification</code> to display batched errors and warnings as <br>toasts during the skill refresh process.<br> <li> Removed the detailed inline diagnostic list in the JSX, replacing it <br>with a color-coded, single-line status summary.<br> <li> Added a toast notification in the <code>catch</code> block to handle and display <br>critical refresh failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/AgentIron/AgentIron/pull/32/files#diff-4df993c565f7f6a33e83a640159c7f1676c968522a8a5ae39a565fc8018b6e13">+41/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

