### PR TITLE
Feature: improve chat status bar and side panels

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Run clippy
         run: cd src-tauri && cargo clippy -- -D warnings
 
-      - name: Build Rust
-        run: cd src-tauri && cargo build
-
       - name: Run Rust tests
         run: cd src-tauri && cargo test
 

--- a/src/components/chat/ChatArea.tsx
+++ b/src/components/chat/ChatArea.tsx
@@ -1,19 +1,16 @@
-import { For, Index, Show, createEffect, createMemo, createSignal, onCleanup, untrack, type Component } from "solid-js";
+import { For, Index, Show, Switch, Match, createEffect, createMemo, createSignal, onCleanup, untrack, type Component } from "solid-js";
 import { Transition } from "solid-transition-group";
-import { TbOutlineServer } from "solid-icons/tb";
 import { useChat } from "@context/ChatContext";
 import { useAgent } from "@context/AgentContext";
 import { useUI } from "@context/UIContext";
-import { useSettings } from "@context/SettingsContext";
-import { useMcp } from "@context/McpContext";
 import { MessageBubble } from "./MessageBubble";
 import { MessageInput } from "./MessageInput";
 import { ApprovalBar } from "./ApprovalBar";
-import { DirectoryIndicator } from "./DirectoryIndicator";
-import { ModelSwitcher } from "./ModelSwitcher";
-import { ContextIndicator } from "./ContextIndicator";
+import { StatusBar } from "./StatusBar";
 import { ToolActivityLine } from "./ToolActivityLine";
 import { ToolActivitySummary } from "./ToolActivitySummary";
+import { ToolHistoryPanel } from "./ToolHistoryPanel";
+import { ModelInfoPanel } from "./ModelInfoPanel";
 import { groupEntries } from "./groupEntries";
 import { McpPanel } from "@components/mcp/McpPanel";
 import type { ChatEntry } from "@/types/message";
@@ -23,9 +20,7 @@ const BOTTOM_SCROLL_THRESHOLD = 48;
 export const ChatArea: Component = () => {
   const { state: chatState, isStreaming } = useChat();
   const { state: agentState } = useAgent();
-  const { mcpPaneOpen, setMcpPaneOpen } = useUI();
-  const { settings } = useSettings();
-  const { serverStatuses } = useMcp();
+  const { rightPane } = useUI();
   let messagesContainerRef: HTMLDivElement | undefined;
   let scrollFrame: number | undefined;
   const [isPinnedToBottom, setIsPinnedToBottom] = createSignal(true);
@@ -112,43 +107,13 @@ export const ChatArea: Component = () => {
     }
   });
 
-  const hasMcpServers = () => settings.mcpServers.length > 0;
-  const connectedCount = () => serverStatuses().filter((s) => s.health === "Connected").length;
-  const hasError = () => serverStatuses().some((s) => s.health === "Error");
-  const mcpButtonColor = () => {
-    if (mcpPaneOpen()) return "text-accent bg-accent-muted";
-    if (hasError()) return "text-error hover:bg-bg-hover";
-    if (connectedCount() > 0) return "text-success hover:bg-bg-hover";
-    return "text-text-secondary hover:text-text-primary hover:bg-bg-hover";
-  };
-
   return (
-    <div class="flex flex-1 min-h-0">
-      {/* Main chat column */}
-      <div class="flex-1 flex flex-col min-w-0">
-        <div class="flex items-center px-4 py-1.5 border-b border-border-subtle bg-bg-secondary/50">
-          <DirectoryIndicator />
-          <div class="flex items-center gap-1 ml-auto">
-            <ContextIndicator />
-            <div class="w-px h-4 bg-border-subtle" />
-            <ModelSwitcher />
-            <Show when={hasMcpServers()}>
-              <div class="w-px h-4 bg-border-subtle" />
-              <button
-                onClick={() => setMcpPaneOpen(!mcpPaneOpen())}
-                class={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors ${mcpButtonColor()}`}
-                title="MCP Servers"
-              >
-                <TbOutlineServer size={13} />
-                <span>
-                  {connectedCount() > 0
-                    ? `${connectedCount()}/${settings.mcpServers.length}`
-                    : settings.mcpServers.length}
-                </span>
-              </button>
-            </Show>
-          </div>
-        </div>
+    <div class="relative flex flex-1 min-h-0 overflow-hidden">
+      {/* Main chat column — reserves space on the right while a panel is open */}
+      <div
+        class="flex-1 flex flex-col min-w-0 transition-[padding] duration-200"
+        classList={{ "pr-80": rightPane() !== null }}
+      >
         <div
           ref={messagesContainerRef}
           class="flex-1 overflow-auto px-6 py-4"
@@ -261,15 +226,33 @@ export const ChatArea: Component = () => {
         <ApprovalBar />
         <div class="px-6 pb-4 pt-2">
           <MessageInput />
+          <StatusBar />
         </div>
       </div>
 
-      {/* MCP right pane */}
-      <Transition name="slide-right">
-        <Show when={mcpPaneOpen()}>
-          <McpPanel />
-        </Show>
-      </Transition>
+      {/* Right side panel — overlay drawer that opens over the reserved space,
+          so switching panels never shifts the chat column. */}
+      <div class="absolute top-0 right-0 bottom-0 w-80 pointer-events-none">
+        <Transition name="slide-right">
+          <Show when={rightPane()} keyed>
+            {(pane) => (
+              <div class="absolute inset-0 pointer-events-auto">
+                <Switch>
+                  <Match when={pane === "mcp"}>
+                    <McpPanel />
+                  </Match>
+                  <Match when={pane === "tools"}>
+                    <ToolHistoryPanel />
+                  </Match>
+                  <Match when={pane === "model"}>
+                    <ModelInfoPanel />
+                  </Match>
+                </Switch>
+              </div>
+            )}
+          </Show>
+        </Transition>
+      </div>
     </div>
   );
 };

--- a/src/components/chat/ContextIndicator.tsx
+++ b/src/components/chat/ContextIndicator.tsx
@@ -8,13 +8,17 @@ export const ContextIndicator: Component = () => {
   const { state: agentState, activeConnection } = useAgent();
   const { allModels } = useSettings();
   const [activeTokens, setActiveTokens] = createSignal(0);
+  // Compact threshold (in tokens) when iron-core supplies it. Absent today —
+  // the marker stays hidden until the backend includes it in the payload.
+  const [compactThreshold, setCompactThreshold] = createSignal<number | undefined>();
 
   onMount(async () => {
-    const unlisten = await listen<{ tabId: string; activeTokens: number }>(
+    const unlisten = await listen<{ tabId: string; activeTokens: number; compactThreshold?: number }>(
       "agent-context-update",
       (e) => {
         if (e.payload.tabId === agentState.activeTabId) {
           setActiveTokens(e.payload.activeTokens);
+          setCompactThreshold(e.payload.compactThreshold);
         }
       },
     );
@@ -45,7 +49,15 @@ export const ContextIndicator: Component = () => {
     const pct = usagePercent();
     if (pct > 90) return "bg-error";
     if (pct > 70) return "bg-warning";
-    return "bg-accent";
+    return "bg-success";
+  };
+
+  // Position of the compact-threshold marker as a percentage of the bar width.
+  const thresholdPercent = () => {
+    const max = maxContext();
+    const threshold = compactThreshold();
+    if (!max || !threshold) return undefined;
+    return Math.min((threshold / max) * 100, 100);
   };
 
   return (
@@ -62,11 +74,18 @@ export const ContextIndicator: Component = () => {
         )}
       </div>
       {maxContext() && activeTokens() > 0 && (
-        <div class="w-16 h-1.5 rounded-full bg-bg-elevated overflow-hidden">
+        <div class="relative w-16 h-1.5 rounded-full bg-bg-elevated overflow-hidden">
           <div
             class={`h-full rounded-full transition-all ${barColor()}`}
             style={{ width: `${usagePercent()}%` }}
           />
+          {thresholdPercent() !== undefined && (
+            <div
+              class="absolute top-0 bottom-0 w-px bg-text-primary/70"
+              style={{ left: `${thresholdPercent()}%` }}
+              title={`Compaction threshold: ${formatTokenCount(compactThreshold()!)}`}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -34,9 +34,9 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
             </div>
           }
         >
-          <div class={`flex justify-end mb-4${animateClass()}`}>
+          <div class={`flex justify-end mb-5${animateClass()}`}>
             <div class="flex items-start gap-3 max-w-[80%]">
-              <div class="bg-bg-tertiary rounded-xl px-4 py-3">
+              <div class="bg-bg-tertiary rounded-xl px-4 py-2.5">
                 <p class="text-sm whitespace-pre-wrap">{props.content}</p>
               </div>
               <div class="flex-shrink-0 w-7 h-7 rounded-full bg-bg-elevated flex items-center justify-center mt-0.5">

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -25,6 +25,7 @@ export const MessageInput: Component = () => {
     setLastAssistantContent,
     setStreaming,
     isStreaming,
+    setStatusOverride,
   } = useChat();
   const { state: agentState } = useAgent();
   const { notify } = useNotification();
@@ -106,6 +107,7 @@ export const MessageInput: Component = () => {
         role: "system", content: "Compacting context...",
         createdAt: new Date().toISOString(),
       });
+      setStatusOverride(tid, "compacting");
       try {
         await compactSession(tid);
         addMessageEntry(tid, {
@@ -119,6 +121,8 @@ export const MessageInput: Component = () => {
           role: "system", content: `Compact failed: ${err}`,
           createdAt: new Date().toISOString(),
         });
+      } finally {
+        setStatusOverride(tid, null);
       }
       return true;
     }
@@ -209,6 +213,8 @@ export const MessageInput: Component = () => {
       if (handled) return;
     }
 
+    // Clear any lingering error state from a previous turn before sending.
+    setStatusOverride(tid, null);
     setStreaming(tid, true);
 
     // Add user message (with image indicator if applicable)
@@ -254,6 +260,7 @@ export const MessageInput: Component = () => {
       }
     } catch (err) {
       appendToLastAssistantContent(tid, `Error: ${err}`);
+      setStatusOverride(tid, "error");
     } finally {
       setStreaming(tid, false);
     }

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -208,13 +208,13 @@ export const MessageInput: Component = () => {
     clearImages();
     if (textareaRef) textareaRef.style.height = "auto";
 
+    // Clear any lingering error state from a previous turn.
+    setStatusOverride(tid, null);
+
     if (content.startsWith("/") && attachedImages.length === 0) {
       const handled = await handleSlashCommand(content);
       if (handled) return;
     }
-
-    // Clear any lingering error state from a previous turn before sending.
-    setStatusOverride(tid, null);
     setStreaming(tid, true);
 
     // Add user message (with image indicator if applicable)

--- a/src/components/chat/ModelInfoPanel.tsx
+++ b/src/components/chat/ModelInfoPanel.tsx
@@ -1,0 +1,116 @@
+import { Show, type Component, type JSX } from "solid-js";
+import { TbOutlineX, TbOutlineInfoCircle, TbOutlineCheck, TbOutlineMinus } from "solid-icons/tb";
+import { useUI } from "@context/UIContext";
+import { useAgent } from "@context/AgentContext";
+import { useSettings } from "@context/SettingsContext";
+import { formatTokenCount } from "@lib/models";
+import type { ModelInfo } from "@/types/settings";
+
+export const ModelInfoPanel: Component = () => {
+  const { closeRightPane } = useUI();
+  const { activeConnection } = useAgent();
+  const { settings, allModels } = useSettings();
+
+  const model = (): ModelInfo | undefined => {
+    const conn = activeConnection();
+    if (!conn?.model) return undefined;
+    return allModels().find((m) => m.id === conn.model && m.providerId === conn.providerId);
+  };
+
+  const providerName = () => {
+    const conn = activeConnection();
+    if (!conn?.providerId) return undefined;
+    return settings.providers.find((p) => p.id === conn.providerId)?.name ?? conn.providerId;
+  };
+
+  const formatCost = (cost: number | undefined) =>
+    cost === undefined ? undefined : `$${cost.toFixed(2)} / 1M tokens`;
+
+  return (
+    <div class="w-80 flex-shrink-0 border-l border-border-default bg-bg-secondary flex flex-col h-full">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+        <div class="flex items-center gap-2">
+          <TbOutlineInfoCircle size={16} class="text-text-tertiary" />
+          <span class="text-sm font-medium text-text-primary">Model Info</span>
+        </div>
+        <button
+          onClick={() => closeRightPane()}
+          class="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors"
+        >
+          <TbOutlineX size={16} />
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto p-4 space-y-4">
+        <Show
+          when={model() ?? (activeConnection()?.model ? { name: activeConnection()!.model } : undefined)}
+          fallback={
+            <div class="text-center py-8">
+              <TbOutlineInfoCircle size={32} class="mx-auto text-text-tertiary mb-2" />
+              <p class="text-sm text-text-tertiary">No active model</p>
+            </div>
+          }
+        >
+          <div>
+            <div class="text-base font-medium text-text-primary">
+              {model()?.name ?? activeConnection()?.model}
+            </div>
+            <Show when={providerName()}>
+              <div class="text-xs text-text-tertiary mt-0.5">{providerName()}</div>
+            </Show>
+          </div>
+
+          <Section title="Limits">
+            <InfoRow
+              label="Context window"
+              value={model()?.contextWindow ? formatTokenCount(model()!.contextWindow!) : undefined}
+            />
+            <InfoRow
+              label="Max output"
+              value={model()?.outputLimit ? formatTokenCount(model()!.outputLimit!) : undefined}
+            />
+          </Section>
+
+          <Section title="Pricing">
+            <InfoRow label="Input" value={formatCost(model()?.costInput)} />
+            <InfoRow label="Output" value={formatCost(model()?.costOutput)} />
+          </Section>
+
+          <Section title="Capabilities">
+            <CapabilityRow label="Tool calling" enabled={model()?.toolCall} />
+            <CapabilityRow label="Reasoning" enabled={model()?.reasoning} />
+            <CapabilityRow label="Vision" enabled={model()?.vision} />
+          </Section>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+const Section: Component<{ title: string; children: JSX.Element }> = (props) => (
+  <div class="space-y-1.5">
+    <div class="text-xs font-medium uppercase tracking-wide text-text-tertiary">{props.title}</div>
+    <div class="space-y-1">{props.children}</div>
+  </div>
+);
+
+const InfoRow: Component<{ label: string; value: string | undefined }> = (props) => (
+  <div class="flex items-baseline justify-between gap-2 text-xs">
+    <span class="text-text-secondary">{props.label}</span>
+    <span class={`font-mono ${props.value ? "text-text-primary" : "text-text-tertiary"}`}>
+      {props.value ?? "—"}
+    </span>
+  </div>
+);
+
+const CapabilityRow: Component<{ label: string; enabled: boolean | undefined }> = (props) => (
+  <div class="flex items-center justify-between gap-2 text-xs">
+    <span class="text-text-secondary">{props.label}</span>
+    <Show
+      when={props.enabled}
+      fallback={<TbOutlineMinus size={14} class="text-text-tertiary" />}
+    >
+      <TbOutlineCheck size={14} class="text-success" />
+    </Show>
+  </div>
+);

--- a/src/components/chat/ModelSwitcher.tsx
+++ b/src/components/chat/ModelSwitcher.tsx
@@ -71,7 +71,7 @@ export const ModelSwitcher: Component = () => {
       </Show>
       <Transition name="scale-fade">
         <Show when={open()}>
-          <div class="absolute left-0 top-full mt-1 w-64 rounded-lg border border-border-default bg-bg-elevated shadow-xl z-20 py-1 max-h-72 overflow-y-auto">
+          <div class="absolute left-0 bottom-full mb-1 w-64 rounded-lg border border-border-default bg-bg-elevated shadow-xl z-20 py-1 max-h-72 overflow-y-auto">
           <Show
             when={starredModels().length > 0}
             fallback={

--- a/src/components/chat/StatusBar.tsx
+++ b/src/components/chat/StatusBar.tsx
@@ -1,0 +1,85 @@
+import { Show, type Component } from "solid-js";
+import {
+  TbOutlineServer,
+  TbOutlineHistory,
+  TbOutlineInfoCircle,
+} from "solid-icons/tb";
+import { useUI } from "@context/UIContext";
+import { useSettings } from "@context/SettingsContext";
+import { useMcp } from "@context/McpContext";
+import { DirectoryIndicator } from "./DirectoryIndicator";
+import { ModelSwitcher } from "./ModelSwitcher";
+import { ContextIndicator } from "./ContextIndicator";
+import { StatusIndicator } from "./StatusIndicator";
+
+export const StatusBar: Component = () => {
+  const { rightPane, toggleRightPane } = useUI();
+  const { settings } = useSettings();
+  const { serverStatuses } = useMcp();
+
+  const mcpServerCount = () => settings.mcpServers.length;
+  const connectedCount = () => serverStatuses().filter((s) => s.health === "Connected").length;
+  const hasError = () => serverStatuses().some((s) => s.health === "Error");
+
+  const mcpButtonColor = () => {
+    if (rightPane() === "mcp") return "text-accent bg-accent-muted";
+    if (hasError()) return "text-error hover:bg-bg-hover";
+    if (connectedCount() > 0) return "text-success hover:bg-bg-hover";
+    return "text-text-secondary hover:text-text-primary hover:bg-bg-hover";
+  };
+
+  const toggleColor = (active: boolean) =>
+    active
+      ? "text-accent bg-accent-muted"
+      : "text-text-secondary hover:text-text-primary hover:bg-bg-hover";
+
+  return (
+    <div class="flex items-center gap-2 mt-1.5 px-1 text-text-secondary">
+      {/* Left zone — switchable settings */}
+      <div class="flex items-center gap-1 min-w-0">
+        <DirectoryIndicator />
+        <div class="w-px h-4 bg-border-subtle" />
+        <ModelSwitcher />
+        <div class="w-px h-4 bg-border-subtle" />
+        <ContextIndicator />
+      </div>
+
+      {/* Center zone — animated status indicator */}
+      <div class="flex-1 flex justify-center">
+        <StatusIndicator />
+      </div>
+
+      {/* Right zone — panel toggles */}
+      <div class="flex items-center gap-1">
+        <button
+          onClick={() => toggleRightPane("mcp")}
+          class={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors ${mcpButtonColor()}`}
+          title="MCP Servers"
+        >
+          <TbOutlineServer size={14} />
+          <Show when={mcpServerCount() > 0}>
+            <span>
+              {connectedCount() > 0
+                ? `${connectedCount()}/${mcpServerCount()}`
+                : mcpServerCount()}
+            </span>
+          </Show>
+        </button>
+        <button
+          onClick={() => toggleRightPane("tools")}
+          class={`p-1.5 rounded-md transition-colors ${toggleColor(rightPane() === "tools")}`}
+          title="Tool History"
+        >
+          <TbOutlineHistory size={14} />
+        </button>
+        <button
+          onClick={() => toggleRightPane("model")}
+          class={`p-1.5 rounded-md transition-colors ${toggleColor(rightPane() === "model")}`}
+          title="Model Info"
+        >
+          <TbOutlineInfoCircle size={14} />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/StatusIndicator.tsx
+++ b/src/components/chat/StatusIndicator.tsx
@@ -1,0 +1,48 @@
+import { type Component } from "solid-js";
+import { useChat, type ChatStatus } from "@context/ChatContext";
+import { useAgent } from "@context/AgentContext";
+
+interface StatusPresentation {
+  label: string;
+  /** Static text color token. */
+  color: string;
+  /** Static dot color token. */
+  dotColor: string;
+  /** Animation class from index.css, if any. */
+  animation?: string;
+  /** Dot-specific animation class from index.css, if any. */
+  dotAnimation?: string;
+}
+
+const PRESENTATION: Record<ChatStatus, StatusPresentation> = {
+  ready: { label: "Ready", color: "text-text-tertiary", dotColor: "bg-text-tertiary" },
+  thinking: { label: "Thinking", color: "text-accent", dotColor: "bg-accent", animation: "status-thinking", dotAnimation: "status-dot-pulse" },
+  // The streaming class paints its own animated gradient text, so no color token.
+  streaming: { label: "Streaming", color: "", dotColor: "bg-accent", animation: "status-streaming", dotAnimation: "status-dot-streaming" },
+  compacting: { label: "Compacting", color: "text-warning", dotColor: "bg-warning", animation: "status-compacting", dotAnimation: "status-dot-pulse" },
+  error: { label: "Error", color: "text-error", dotColor: "bg-error", animation: "status-error", dotAnimation: "status-dot-error" },
+  waiting: { label: "Waiting", color: "text-accent", dotColor: "bg-accent", animation: "status-thinking", dotAnimation: "status-dot-pulse" },
+};
+
+export const StatusIndicator: Component = () => {
+  const { getStatus } = useChat();
+  const { state: agentState } = useAgent();
+
+  const status = () => getStatus(agentState.activeTabId ?? "");
+  const presentation = () => PRESENTATION[status()];
+
+  return (
+    <span
+      class="inline-flex items-center gap-1.5 text-xs font-medium tracking-wide select-none"
+      title={`Agent status: ${presentation().label}`}
+    >
+      <span
+        aria-hidden="true"
+        class={`h-1.5 w-1.5 rounded-full ${presentation().dotColor} ${presentation().dotAnimation ?? ""}`}
+      />
+      <span class={`${presentation().color} ${presentation().animation ?? ""}`}>
+        {presentation().label}
+      </span>
+    </span>
+  );
+};

--- a/src/components/chat/ToolActivitySummary.tsx
+++ b/src/components/chat/ToolActivitySummary.tsx
@@ -5,8 +5,8 @@ import {
   TbOutlineChevronDown,
   TbOutlineChevronRight,
 } from "solid-icons/tb";
-import { toolIcon, buildToolGroupSummary, formatScriptActivityLabel, formatScriptActivitySummary, formatToolCounts } from "./toolUtils";
-import { renderArgsDetail, renderResult } from "./ToolDetailRenderers";
+import { toolIcon, buildToolGroupSummary, formatScriptActivityLabel, formatScriptActivitySummary, formatToolCounts, isCompactionTool } from "./toolUtils";
+import { renderArgsDetail, renderResult, renderCompactionResult } from "./ToolDetailRenderers";
 import type { ChatEntry } from "@/types/message";
 import type { ToolEvent } from "@/types/agent";
 
@@ -24,13 +24,18 @@ export const ToolActivitySummary: Component<ToolActivitySummaryProps> = (props) 
 
   const summary = () => buildToolGroupSummary(toolEvents());
   const countLabel = () => formatToolCounts(summary().nameCounts);
+  const hasCompaction = () => toolEvents().some((e) => isCompactionTool(e.toolName));
 
   return (
     <div class={`ml-10 mb-3 ${summary().allReadOnly ? "opacity-50" : ""}`}>
       {/* Collapsed summary line */}
       <button
         onClick={() => setExpanded(!expanded())}
-        class="flex items-center gap-2 w-full px-3 py-1.5 text-xs rounded-lg border border-border-subtle bg-bg-secondary/50 hover:bg-bg-hover transition-colors"
+        class={`flex items-center gap-2 w-full px-3 py-1.5 text-xs rounded-lg border transition-colors ${
+          hasCompaction()
+            ? "border-accent/30 bg-accent-muted hover:bg-accent-muted/70"
+            : "border-border-subtle bg-bg-secondary/50 hover:bg-bg-hover"
+        }`}
       >
         {summary().hasErrors ? (
           <TbOutlineAlertTriangle size={13} class="text-warning flex-shrink-0" />
@@ -119,7 +124,9 @@ const ToolDetailItem: Component<{ event: ToolEvent }> = (props) => {
             <div class="pt-1 border-t border-border-subtle">
               <span class="text-xs text-text-tertiary">Result:</span>
               <div class="mt-1">
-                {renderResult(props.event.toolName, props.event.result)}
+                {(isCompactionTool(props.event.toolName) &&
+                  renderCompactionResult(props.event.result)) ||
+                  renderResult(props.event.toolName, props.event.result)}
               </div>
             </div>
           </Show>

--- a/src/components/chat/ToolDetailRenderers.tsx
+++ b/src/components/chat/ToolDetailRenderers.tsx
@@ -1,5 +1,8 @@
 import { For, Show, type Component, type JSX } from "solid-js";
+import { TbOutlineArchive, TbOutlineArrowNarrowRight } from "solid-icons/tb";
 import { CodeBlock } from "./CodeBlock";
+import { extractCompactionMetrics, formatCompactionDelta } from "./toolUtils";
+import { formatTokenCount } from "@lib/models";
 
 // ── Argument detail renderers ──
 
@@ -82,6 +85,41 @@ export function renderArgsDetail(toolName: string | undefined, args: unknown): J
         </pre>
       );
   }
+}
+
+// ── Compaction renderer (graceful stub) ──
+//
+// Renders a distinct token-reduction summary when iron-core supplies compaction
+// metrics in the result. Returns null when no metrics are present, so callers
+// can fall back to the generic result renderer until backend support lands.
+
+export function renderCompactionResult(result: unknown): JSX.Element {
+  const metrics = extractCompactionMetrics(result);
+  if (!metrics) return null;
+  const delta = formatCompactionDelta(metrics);
+
+  return (
+    <div class="flex flex-col gap-1.5 rounded-lg border border-accent/30 bg-accent-muted px-3 py-2">
+      <div class="flex items-center gap-2 text-xs">
+        <TbOutlineArchive size={14} class="text-accent flex-shrink-0" />
+        <span class="font-medium text-text-primary">Context compacted</span>
+      </div>
+      <Show when={metrics.tokensBefore !== undefined && metrics.tokensAfter !== undefined}>
+        <div class="flex items-center gap-2 text-xs font-mono text-text-secondary">
+          <span>{formatTokenCount(metrics.tokensBefore!)}</span>
+          <TbOutlineArrowNarrowRight size={14} class="text-text-tertiary" />
+          <span class="text-success">{formatTokenCount(metrics.tokensAfter!)}</span>
+          <span class="text-text-tertiary">tokens</span>
+        </div>
+      </Show>
+      <Show when={(metrics.tokensBefore === undefined || metrics.tokensAfter === undefined) && delta}>
+        <div class="text-xs font-mono text-text-secondary">{delta}</div>
+      </Show>
+      <Show when={metrics.method}>
+        <DetailRow label="Method" value={metrics.method} />
+      </Show>
+    </div>
+  );
 }
 
 // ── Result renderer ──

--- a/src/components/chat/ToolHistoryPanel.tsx
+++ b/src/components/chat/ToolHistoryPanel.tsx
@@ -66,10 +66,13 @@ const ToolHistoryRow: Component<{ event: ToolEvent }> = (props) => {
   const isResult = () => props.event.type === "tool_result";
   const isScriptActivity = () => props.event.type === "script_activity";
   const statusLabel = () =>
-    isResult() || isScriptActivity() ? props.event.status : "Running";
+    isResult() || isScriptActivity() ? (props.event.status ?? "Running") : "Running";
   const statusColor = () => {
     if (isResult() || isScriptActivity()) {
-      return props.event.status === "Completed" ? "text-success" : "text-error";
+      const status = (props.event.status ?? "").toLowerCase();
+      if (status === "completed" || status === "success") return "text-success";
+      if (status.includes("fail") || status.includes("error") || status === "cancelled") return "text-error";
+      return "text-accent";
     }
     return "text-accent";
   };

--- a/src/components/chat/ToolHistoryPanel.tsx
+++ b/src/components/chat/ToolHistoryPanel.tsx
@@ -1,0 +1,126 @@
+import { For, Show, createSignal, type Component } from "solid-js";
+import {
+  TbOutlineX,
+  TbOutlineHistory,
+  TbOutlineChevronDown,
+  TbOutlineChevronRight,
+} from "solid-icons/tb";
+import { useUI } from "@context/UIContext";
+import { useChat } from "@context/ChatContext";
+import { useAgent } from "@context/AgentContext";
+import {
+  toolIcon,
+  formatScriptActivityLabel,
+  formatScriptActivitySummary,
+  isCompactionTool,
+} from "./toolUtils";
+import { renderArgsDetail, renderResult, renderCompactionResult } from "./ToolDetailRenderers";
+import type { ToolEvent } from "@/types/agent";
+
+export const ToolHistoryPanel: Component = () => {
+  const { closeRightPane } = useUI();
+  const { getToolHistory } = useChat();
+  const { state: agentState } = useAgent();
+
+  const history = () => getToolHistory(agentState.activeTabId ?? "");
+
+  return (
+    <div class="w-80 flex-shrink-0 border-l border-border-default bg-bg-secondary flex flex-col h-full">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+        <div class="flex items-center gap-2">
+          <TbOutlineHistory size={16} class="text-text-tertiary" />
+          <span class="text-sm font-medium text-text-primary">Tool History</span>
+        </div>
+        <button
+          onClick={() => closeRightPane()}
+          class="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors"
+        >
+          <TbOutlineX size={16} />
+        </button>
+      </div>
+      <div class="flex-1 overflow-y-auto p-2 space-y-1">
+        <Show
+          when={history().length > 0}
+          fallback={
+            <div class="text-center py-8">
+              <TbOutlineHistory size={32} class="mx-auto text-text-tertiary mb-2" />
+              <p class="text-sm text-text-tertiary">No tool calls yet</p>
+              <p class="text-xs text-text-tertiary mt-1">
+                Tool activity for this tab will appear here.
+              </p>
+            </div>
+          }
+        >
+          <For each={history()}>
+            {(entry) => <ToolHistoryRow event={entry.toolEvent!} />}
+          </For>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+const ToolHistoryRow: Component<{ event: ToolEvent }> = (props) => {
+  const [open, setOpen] = createSignal(false);
+
+  const isResult = () => props.event.type === "tool_result";
+  const isScriptActivity = () => props.event.type === "script_activity";
+  const statusLabel = () =>
+    isResult() || isScriptActivity() ? props.event.status : "Running";
+  const statusColor = () => {
+    if (isResult() || isScriptActivity()) {
+      return props.event.status === "Completed" ? "text-success" : "text-error";
+    }
+    return "text-accent";
+  };
+  const title = () =>
+    isScriptActivity()
+      ? formatScriptActivityLabel(props.event.activityType)
+      : props.event.toolName;
+  const detailSummary = () =>
+    isScriptActivity() ? formatScriptActivitySummary(props.event.detail) : "";
+
+  return (
+    <div class="rounded-lg border border-border-subtle bg-bg-secondary/50 overflow-hidden">
+      <button
+        onClick={() => setOpen(!open())}
+        class="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-bg-hover transition-colors"
+      >
+        {toolIcon(props.event.toolName)}
+        <span class="font-medium text-text-primary truncate">{title()}</span>
+        <Show when={detailSummary()}>
+          <span class="text-text-tertiary font-mono truncate max-w-[40%]">{detailSummary()}</span>
+        </Show>
+        <span class={`ml-auto flex-shrink-0 ${statusColor()}`}>{statusLabel()}</span>
+        <span class="text-text-tertiary flex-shrink-0">
+          {open() ? <TbOutlineChevronDown size={12} /> : <TbOutlineChevronRight size={12} />}
+        </span>
+      </button>
+      <Show when={open()}>
+        <div class="border-t border-border-subtle px-3 py-2 space-y-2">
+          <Show when={props.event.arguments}>
+            {renderArgsDetail(props.event.toolName, props.event.arguments)}
+          </Show>
+          <Show when={isScriptActivity() && props.event.detail !== undefined}>
+            <div class="pt-1 border-t border-border-subtle">
+              <span class="text-xs text-text-tertiary">Details:</span>
+              <pre class="mt-1 bg-bg-primary rounded p-2 overflow-x-auto font-mono text-text-secondary text-xs max-h-48 overflow-y-auto whitespace-pre-wrap">
+                {JSON.stringify(props.event.detail, null, 2)}
+              </pre>
+            </div>
+          </Show>
+          <Show when={isResult() && props.event.result !== undefined}>
+            <div class="pt-1 border-t border-border-subtle">
+              <span class="text-xs text-text-tertiary">Result:</span>
+              <div class="mt-1">
+                {(isCompactionTool(props.event.toolName) &&
+                  renderCompactionResult(props.event.result)) ||
+                  renderResult(props.event.toolName, props.event.result)}
+              </div>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/chat/toolUtils.tsx
+++ b/src/components/chat/toolUtils.tsx
@@ -8,10 +8,15 @@ import {
   TbOutlineTerminal,
   TbOutlineBrandPython,
   TbOutlineWorldWww,
+  TbOutlineArchive,
 } from "solid-icons/tb";
+import { formatTokenCount } from "@lib/models";
 
 export function toolIcon(name: string | undefined, size = 14): JSX.Element {
   const cls = "flex-shrink-0";
+  if (isCompactionTool(name)) {
+    return <TbOutlineArchive size={size} class={`${cls} text-accent`} />;
+  }
   switch (name) {
     case "read":
       return <TbOutlineFileText size={size} class={`${cls} text-amber-light`} />;
@@ -33,6 +38,54 @@ export function toolIcon(name: string | undefined, size = 14): JSX.Element {
     default:
       return <TbOutlineTerminal size={size} class={`${cls} text-text-tertiary`} />;
   }
+}
+
+// ── Compaction classification (graceful stub) ──
+//
+// iron-core does not yet emit compaction as a tool event. These helpers detect
+// it by name and pull token metrics from the result when present, so the UI
+// lights up automatically once the backend support lands. Until then they are
+// dormant. See the linked iron-core follow-up issue.
+
+const COMPACTION_TOOL_NAMES = new Set(["compact", "compaction"]);
+
+export function isCompactionTool(name: string | undefined): boolean {
+  return name ? COMPACTION_TOOL_NAMES.has(name) : false;
+}
+
+export interface CompactionMetrics {
+  tokensBefore?: number;
+  tokensAfter?: number;
+  method?: string;
+}
+
+/** Extract compaction token metrics from a tool result, tolerating naming variants. */
+export function extractCompactionMetrics(result: unknown): CompactionMetrics | null {
+  if (!result || typeof result !== "object") return null;
+  const r = result as Record<string, unknown>;
+  const num = (...keys: string[]): number | undefined => {
+    for (const key of keys) {
+      const value = r[key];
+      if (typeof value === "number") return value;
+    }
+    return undefined;
+  };
+  const tokensBefore = num("tokens_before", "tokensBefore");
+  const tokensAfter = num("tokens_after", "tokensAfter");
+  const method = typeof r.method === "string" ? r.method : undefined;
+  if (tokensBefore === undefined && tokensAfter === undefined && !method) return null;
+  return { tokensBefore, tokensAfter, method };
+}
+
+/** "12.4k → 8.1k tokens" when both endpoints are known. */
+export function formatCompactionDelta(metrics: CompactionMetrics): string {
+  const { tokensBefore, tokensAfter } = metrics;
+  if (tokensBefore !== undefined && tokensAfter !== undefined) {
+    return `${formatTokenCount(tokensBefore)} → ${formatTokenCount(tokensAfter)} tokens`;
+  }
+  if (tokensAfter !== undefined) return `${formatTokenCount(tokensAfter)} tokens`;
+  if (tokensBefore !== undefined) return `${formatTokenCount(tokensBefore)} tokens`;
+  return "";
 }
 
 export function formatArgsSummary(toolName: string | undefined, args: unknown): string {

--- a/src/components/mcp/McpPanel.tsx
+++ b/src/components/mcp/McpPanel.tsx
@@ -8,7 +8,7 @@ import { McpServerDetail } from "./McpServerDetail";
 import type { McpServerConfig } from "@/types/settings";
 
 export const McpPanel: Component = () => {
-  const { setMcpPaneOpen } = useUI();
+  const { closeRightPane } = useUI();
   const { settings } = useSettings();
   const { getServerStatus, refresh } = useMcp();
   const [selectedServer, setSelectedServer] = createSignal<McpServerConfig | null>(null);
@@ -29,7 +29,7 @@ export const McpPanel: Component = () => {
                 <span class="text-sm font-medium text-text-primary">MCP Servers</span>
               </div>
               <button
-                onClick={() => setMcpPaneOpen(false)}
+                onClick={() => closeRightPane()}
                 class="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors"
               >
                 <TbOutlineX size={16} />

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -20,12 +20,28 @@ interface PendingApproval {
   arguments: unknown;
 }
 
+/** Effective agent activity state shown by the status indicator. */
+export type ChatStatus =
+  | "ready"
+  | "thinking"
+  | "streaming"
+  | "compacting"
+  | "error"
+  | "waiting";
+
+/** States that must be set explicitly because they cannot be derived from the stream. */
+type StatusOverride = "compacting" | "error" | null;
+
 interface ChatState {
   entriesByTab: Record<string, ChatEntry[]>;
   streamingByTab: Record<string, boolean>;
   pendingApprovalByTab: Record<string, PendingApproval | null>;
   autoApprovedToolsByTab: Record<string, string[]>;
+  statusOverrideByTab: Record<string, StatusOverride>;
 }
+
+/** Most recent tool calls surfaced first; capped for the tool history panel. */
+const TOOL_HISTORY_LIMIT = 25;
 
 interface ChatContextValue {
   state: ChatState;
@@ -36,6 +52,9 @@ interface ChatContextValue {
   clearEntries: (tabId: string) => void;
   setStreaming: (tabId: string, streaming: boolean) => void;
   isStreaming: (tabId: string) => boolean;
+  setStatusOverride: (tabId: string, override: StatusOverride) => void;
+  getStatus: (tabId: string) => ChatStatus;
+  getToolHistory: (tabId: string) => ChatEntry[];
   getPendingApproval: (tabId: string) => PendingApproval | null;
   respondApproval: (tabId: string, callId: string, approved: boolean) => void;
   respondApproveAll: (tabId: string, callId: string, toolName: string) => void;
@@ -50,6 +69,7 @@ export const ChatProvider: Component<{ children: JSX.Element }> = (props) => {
     streamingByTab: {},
     pendingApprovalByTab: {},
     autoApprovedToolsByTab: {},
+    statusOverrideByTab: {},
   });
 
   // ── Event listeners (moved from ChatArea) ──
@@ -124,6 +144,12 @@ export const ChatProvider: Component<{ children: JSX.Element }> = (props) => {
         const { tabId } = e.payload;
         setState("streamingByTab", tabId, false);
         setState("pendingApprovalByTab", tabId, null);
+        // A clean finish clears any transient compacting state; errors are set
+        // explicitly by the caller after this event, so leave "error" intact.
+        const override = untrack(() => state.statusOverrideByTab[tabId]);
+        if (override === "compacting") {
+          setState("statusOverrideByTab", tabId, null);
+        }
       }),
     );
   });
@@ -213,6 +239,26 @@ export const ChatProvider: Component<{ children: JSX.Element }> = (props) => {
     setStreaming: (tabId, streaming) =>
       setState("streamingByTab", tabId, streaming),
     isStreaming: (tabId) => state.streamingByTab[tabId] ?? false,
+    setStatusOverride: (tabId, override) =>
+      setState("statusOverrideByTab", tabId, override),
+    getStatus: (tabId) => {
+      const override = state.statusOverrideByTab[tabId];
+      if (override) return override;
+      if (state.pendingApprovalByTab[tabId]) return "waiting";
+      if (state.streamingByTab[tabId] ?? false) {
+        // "thinking" is the gap between sending and the first stream chunk:
+        // streaming is active but the latest assistant turn is still empty.
+        return lastAssistantIsEmpty(state.entriesByTab[tabId] ?? [])
+          ? "thinking"
+          : "streaming";
+      }
+      return "ready";
+    },
+    getToolHistory: (tabId) => {
+      const entries = state.entriesByTab[tabId] ?? [];
+      const toolEntries = entries.filter((e) => e.type === "tool_event");
+      return toolEntries.slice(-TOOL_HISTORY_LIMIT).reverse();
+    },
     getPendingApproval: (tabId) => state.pendingApprovalByTab[tabId] ?? null,
     respondApproval: (tabId, callId, approved) => {
       respondToApproval(tabId, callId, approved);
@@ -237,6 +283,17 @@ export const ChatProvider: Component<{ children: JSX.Element }> = (props) => {
     <ChatContext.Provider value={value}>{props.children}</ChatContext.Provider>
   );
 };
+
+/** True when the most recent assistant message exists but has no content yet. */
+function lastAssistantIsEmpty(entries: ChatEntry[]): boolean {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type === "message" && entry.message?.role === "assistant") {
+      return !entry.message.content;
+    }
+  }
+  return false;
+}
 
 export const useChat = () => {
   const ctx = useContext(ChatContext);

--- a/src/context/UIContext.tsx
+++ b/src/context/UIContext.tsx
@@ -2,6 +2,9 @@ import { createContext, useContext, createSignal, type Component, type JSX } fro
 
 export type AppView = "chat" | "settings";
 
+/** Which right-side panel is currently shown (only one at a time). */
+export type RightPane = "mcp" | "tools" | "model" | null;
+
 interface UIContextValue {
   sidebarOpen: () => boolean;
   setSidebarOpen: (open: boolean) => void;
@@ -9,8 +12,12 @@ interface UIContextValue {
   setQuickLaunchOpen: (open: boolean) => void;
   currentView: () => AppView;
   setCurrentView: (view: AppView) => void;
+  rightPane: () => RightPane;
+  /** Open the given pane, or close it if it is already open (mutually exclusive). */
+  toggleRightPane: (pane: Exclude<RightPane, null>) => void;
+  closeRightPane: () => void;
+  /** Convenience accessor: true when the MCP pane is the active right pane. */
   mcpPaneOpen: () => boolean;
-  setMcpPaneOpen: (open: boolean) => void;
 }
 
 const UIContext = createContext<UIContextValue>();
@@ -19,7 +26,11 @@ export const UIProvider: Component<{ children: JSX.Element }> = (props) => {
   const [sidebarOpen, setSidebarOpen] = createSignal(true);
   const [quickLaunchOpen, setQuickLaunchOpen] = createSignal(false);
   const [currentView, setCurrentView] = createSignal<AppView>("chat");
-  const [mcpPaneOpen, setMcpPaneOpen] = createSignal(false);
+  const [rightPane, setRightPane] = createSignal<RightPane>(null);
+
+  const toggleRightPane = (pane: Exclude<RightPane, null>) =>
+    setRightPane((current) => (current === pane ? null : pane));
+  const closeRightPane = () => setRightPane(null);
 
   const value: UIContextValue = {
     sidebarOpen,
@@ -28,8 +39,10 @@ export const UIProvider: Component<{ children: JSX.Element }> = (props) => {
     setQuickLaunchOpen,
     currentView,
     setCurrentView,
-    mcpPaneOpen,
-    setMcpPaneOpen,
+    rightPane,
+    toggleRightPane,
+    closeRightPane,
+    mcpPaneOpen: () => rightPane() === "mcp",
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -336,6 +336,66 @@ body {
     to { opacity: 1; }
   }
   .animate-fade-in { animation: fade-in 300ms ease-out; }
+
+  /* ── Status indicator animations (gentle, non-distracting) ── */
+
+  /* Thinking: slow breathing pulse while waiting for the first chunk */
+  @keyframes status-thinking {
+    0%, 100% { opacity: 0.55; }
+    50% { opacity: 1; }
+  }
+  .status-thinking { animation: status-thinking 1.6s ease-in-out infinite; }
+
+  @keyframes status-dot-pulse {
+    0%, 100% { opacity: 0.45; transform: scale(0.85); }
+    50% { opacity: 1; transform: scale(1.15); }
+  }
+  .status-dot-pulse { animation: status-dot-pulse 1.6s ease-in-out infinite; }
+
+  /* Streaming: soft horizontal shimmer to convey forward motion */
+  @keyframes status-streaming {
+    0% { background-position: 0% 50%; }
+    100% { background-position: 200% 50%; }
+  }
+  .status-streaming {
+    background-image: linear-gradient(
+      90deg,
+      var(--color-accent) 0%,
+      var(--color-accent-hover) 50%,
+      var(--color-accent) 100%
+    );
+    background-size: 200% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: status-streaming 2s linear infinite;
+  }
+
+  @keyframes status-dot-streaming {
+    0%, 100% { opacity: 0.55; box-shadow: 0 0 0 0 rgba(217, 119, 6, 0); }
+    50% { opacity: 1; box-shadow: 0 0 0 4px rgba(217, 119, 6, 0.14); }
+  }
+  .status-dot-streaming { animation: status-dot-streaming 1.2s ease-in-out infinite; }
+
+  /* Compacting: gentle pulse on a cooler hue */
+  @keyframes status-compacting {
+    0%, 100% { opacity: 0.6; }
+    50% { opacity: 1; }
+  }
+  .status-compacting { animation: status-compacting 1.2s ease-in-out infinite; }
+
+  /* Error: a couple of attention flashes, then settle */
+  @keyframes status-error {
+    0%, 100% { opacity: 1; }
+    25%, 75% { opacity: 0.4; }
+  }
+  .status-error { animation: status-error 0.9s ease-in-out 2; }
+
+  @keyframes status-dot-error {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    25%, 75% { opacity: 0.45; transform: scale(1.25); }
+  }
+  .status-dot-error { animation: status-dot-error 0.9s ease-in-out 2; }
 }
 
 /* Non-animated base styles for streaming dots and spinner */


### PR DESCRIPTION
## Summary\n- move chat controls into a compact bottom status bar\n- add animated agent status indicator with thinking, streaming, waiting, compacting, and error states\n- add tool history and model info right-side panels\n- enhance context usage and compaction visual treatment\n\n## Verification\n- pnpm exec tsc --noEmit\n- pnpm lint\n- pnpm build\n\nCloses #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status bar with agent status, model info, and quick pane toggles
  * Right-side pane system (MCP, tool history, model details)
  * Tool history panel and model info panel
  * Compaction-aware tool rendering and detection

* **UI/Styling**
  * Animated status indicators (thinking, streaming, compacting, error)
  * Token-usage bar shows compaction threshold marker
  * Minor spacing and dropdown positioning tweaks

* **Behavior**
  * Per-tab status overrides (compacting/error) and improved status determination
<!-- end of auto-generated comment: release notes by coderabbit.ai -->