### PR TITLE
Un-stub compaction indicator and context threshold marker

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -322,22 +322,24 @@ pub async fn create_agent(
         skill_config = skill_config.with_additional_skill_dir(PathBuf::from(dir));
     }
 
+    let context_management = iron_core::ContextManagementConfig::new()
+        .enabled()
+        .with_maintenance_threshold(50_000);
+
     let config = iron_core::Config::default()
         .with_model(model.clone())
         .with_provider_name(&pid)
         .with_max_iterations(10)
         .with_embedded_python_enabled()
-        .with_context_management(
-            iron_core::ContextManagementConfig::new()
-                .enabled()
-                .with_maintenance_threshold(50_000),
-        )
+        .with_context_management(context_management.clone())
         .with_mcp(
             iron_core::McpConfig::new()
                 .with_enabled(true)
                 .with_enabled_by_default(true),
         )
         .with_skills(skill_config);
+
+    let compact_threshold_tokens = context_management.maintenance_threshold;
 
     let work_dir = working_directory
         .map(PathBuf::from)
@@ -357,6 +359,7 @@ pub async fn create_agent(
             working_directory: work_dir,
             mcp_servers: mcp_servers.unwrap_or_default(),
             debug_enabled: state.debug_enabled,
+            compact_threshold_tokens: Some(compact_threshold_tokens),
         },
         request_rx,
     );

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -293,6 +293,7 @@ pub struct AgentParams {
     pub working_directory: PathBuf,
     pub mcp_servers: Vec<McpServerConfigJson>,
     pub debug_enabled: bool,
+    pub compact_threshold_tokens: Option<usize>,
 }
 
 unsafe impl Send for AgentParams {}
@@ -406,6 +407,8 @@ pub fn spawn_agent_worker(params: AgentParams, mut request_rx: mpsc::Receiver<Ag
                 }
             };
 
+            let compact_threshold_tokens = params.compact_threshold_tokens;
+
             while let Some(request) = request_rx.recv().await {
                 match request {
                     AgentRequest::Prompt {
@@ -423,7 +426,7 @@ pub fn spawn_agent_worker(params: AgentParams, mut request_rx: mpsc::Receiver<Ag
                             &mut request_rx,
                         )
                         .await;
-                        emit_token_count(&session, &app_handle, &tab_id);
+                        emit_token_count(&session, &app_handle, &tab_id, compact_threshold_tokens);
                         let _ = response_tx.send(result);
                     }
                     AgentRequest::PromptWithBlocks {
@@ -451,7 +454,7 @@ pub fn spawn_agent_worker(params: AgentParams, mut request_rx: mpsc::Receiver<Ag
                             &mut request_rx,
                         )
                         .await;
-                        emit_token_count(&session, &app_handle, &tab_id);
+                        emit_token_count(&session, &app_handle, &tab_id, compact_threshold_tokens);
                         let _ = response_tx.send(result);
                     }
                     AgentRequest::GetMcpStatus { response_tx } => {
@@ -550,7 +553,7 @@ pub fn spawn_agent_worker(params: AgentParams, mut request_rx: mpsc::Receiver<Ag
                         let _ = response_tx.send(result);
                     }
                     AgentRequest::GetTokenCount { tab_id, app_handle } => {
-                        emit_token_count(&session, &app_handle, &tab_id);
+                        emit_token_count(&session, &app_handle, &tab_id, compact_threshold_tokens);
                     }
                     AgentRequest::Compact {
                         tab_id,
@@ -558,7 +561,7 @@ pub fn spawn_agent_worker(params: AgentParams, mut request_rx: mpsc::Receiver<Ag
                         response_tx,
                     } => {
                         let result = session.checkpoint().await.map_err(|e| e.to_string());
-                        emit_token_count(&session, &app_handle, &tab_id);
+                        emit_token_count(&session, &app_handle, &tab_id, compact_threshold_tokens);
                         let _ = response_tx.send(result);
                     }
                     AgentRequest::CancelActivePrompt { response_tx } => {
@@ -743,6 +746,70 @@ async fn handle_prompt_stream(
                             }),
                         );
                     }
+                    iron_core::PromptEvent::CompactionStarted { compaction_id, method } => {
+                        let _ = app_handle.emit(
+                            "agent-compaction-status",
+                            serde_json::json!({
+                                "tabId": tab_id,
+                                "status": "started",
+                                "compactionId": compaction_id,
+                                "method": method,
+                            }),
+                        );
+                    }
+                    iron_core::PromptEvent::CompactionFinished {
+                        compaction_id,
+                        tokens_before,
+                        tokens_after,
+                        method,
+                    } => {
+                        let _ = app_handle.emit(
+                            "agent-compaction-status",
+                            serde_json::json!({
+                                "tabId": tab_id,
+                                "status": "finished",
+                                "compactionId": compaction_id,
+                                "method": method,
+                            }),
+                        );
+                        let _ = app_handle.emit(
+                            "agent-tool-event",
+                            serde_json::json!({
+                                "tabId": tab_id,
+                                "type": "tool_result",
+                                "callId": compaction_id,
+                                "toolName": "compaction",
+                                "status": "Completed",
+                                "result": {
+                                    "tokens_before": tokens_before,
+                                    "tokens_after": tokens_after,
+                                    "method": method,
+                                },
+                            }),
+                        );
+                    }
+                    iron_core::PromptEvent::CompactionFailed { compaction_id, reason } => {
+                        let _ = app_handle.emit(
+                            "agent-compaction-status",
+                            serde_json::json!({
+                                "tabId": tab_id,
+                                "status": "failed",
+                                "compactionId": compaction_id,
+                                "reason": reason,
+                            }),
+                        );
+                        let _ = app_handle.emit(
+                            "agent-tool-event",
+                            serde_json::json!({
+                                "tabId": tab_id,
+                                "type": "tool_result",
+                                "callId": compaction_id,
+                                "toolName": "compaction",
+                                "status": "Failed",
+                                "result": { "error": reason },
+                            }),
+                        );
+                    }
                     _ => {}
                 }
             }
@@ -837,7 +904,7 @@ async fn handle_active_request(
             true
         }
         AgentRequest::GetTokenCount { tab_id, app_handle } => {
-            emit_token_count(session, &app_handle, &tab_id);
+            emit_token_count(session, &app_handle, &tab_id, None);
             false
         }
         AgentRequest::Compact { response_tx, .. } => {
@@ -1023,11 +1090,16 @@ fn emit_token_count(
     session: &iron_core::AgentSession,
     app_handle: &tauri::AppHandle,
     tab_id: &str,
+    compact_threshold_tokens: Option<usize>,
 ) {
     use tauri::Emitter;
     let tokens = session.uncompacted_tokens();
     let _ = app_handle.emit(
         "agent-context-update",
-        serde_json::json!({ "tabId": tab_id, "activeTokens": tokens }),
+        serde_json::json!({
+            "tabId": tab_id,
+            "activeTokens": tokens,
+            "compactThreshold": compact_threshold_tokens,
+        }),
     );
 }

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -25,7 +25,6 @@ export const MessageInput: Component = () => {
     setLastAssistantContent,
     setStreaming,
     isStreaming,
-    setStatusOverride,
   } = useChat();
   const { state: agentState } = useAgent();
   const { notify } = useNotification();
@@ -107,7 +106,6 @@ export const MessageInput: Component = () => {
         role: "system", content: "Compacting context...",
         createdAt: new Date().toISOString(),
       });
-      setStatusOverride(tid, "compacting");
       try {
         await compactSession(tid);
         addMessageEntry(tid, {
@@ -121,8 +119,6 @@ export const MessageInput: Component = () => {
           role: "system", content: `Compact failed: ${err}`,
           createdAt: new Date().toISOString(),
         });
-      } finally {
-        setStatusOverride(tid, null);
       }
       return true;
     }

--- a/src/components/chat/ToolDetailRenderers.tsx
+++ b/src/components/chat/ToolDetailRenderers.tsx
@@ -87,11 +87,11 @@ export function renderArgsDetail(toolName: string | undefined, args: unknown): J
   }
 }
 
-// ── Compaction renderer (graceful stub) ──
+// ── Compaction renderer ──
 //
 // Renders a distinct token-reduction summary when iron-core supplies compaction
-// metrics in the result. Returns null when no metrics are present, so callers
-// can fall back to the generic result renderer until backend support lands.
+// metrics in the result. Returns null when no metrics are present so callers
+// fall back to the generic result renderer.
 
 export function renderCompactionResult(result: unknown): JSX.Element {
   const metrics = extractCompactionMetrics(result);

--- a/src/components/chat/toolUtils.tsx
+++ b/src/components/chat/toolUtils.tsx
@@ -40,12 +40,11 @@ export function toolIcon(name: string | undefined, size = 14): JSX.Element {
   }
 }
 
-// ── Compaction classification (graceful stub) ──
+// ── Compaction classification ──
 //
-// iron-core does not yet emit compaction as a tool event. These helpers detect
-// it by name and pull token metrics from the result when present, so the UI
-// lights up automatically once the backend support lands. Until then they are
-// dormant. See the linked iron-core follow-up issue.
+// iron-core emits compaction lifecycle events as synthetic tool results with
+// toolName "compaction". These helpers detect them and pull token metrics from
+// the result so the transcript can render a distinct compaction entry.
 
 const COMPACTION_TOOL_NAMES = new Set(["compact", "compaction"]);
 

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -152,6 +152,24 @@ export const ChatProvider: Component<{ children: JSX.Element }> = (props) => {
         }
       }),
     );
+
+    // Compaction lifecycle events from iron-core drive the "compacting" status.
+    unlisteners.push(
+      await listen<{ tabId: string; status: "started" | "finished" | "failed"; reason?: string }>(
+        "agent-compaction-status",
+        (e) => {
+          const { tabId, status } = e.payload;
+          if (status === "started") {
+            setState("statusOverrideByTab", tabId, "compacting");
+          } else {
+            const override = untrack(() => state.statusOverrideByTab[tabId]);
+            if (override === "compacting") {
+              setState("statusOverrideByTab", tabId, null);
+            }
+          }
+        },
+      ),
+    );
   });
 
   onCleanup(() => {


### PR DESCRIPTION
Closes #51

## Summary
Wires the iron-core compaction lifecycle events (released in iron-core v0.1.31, currently on v0.1.32) into the AgentIron UI.

## Changes
- Backend now forwards CompactionStarted/CompactionFinished/CompactionFailed prompt events.
- Added agent-compaction-status Tauri event so the status indicator shows "compacting" for automatic compaction.
- Compaction results are emitted as synthetic agent-tool-event entries with toolName "compaction" and token metrics, lighting up the existing compaction transcript renderer.
- agent-context-update now includes compactThreshold from the agent's context-management config, so the context bar threshold marker renders.
- Removed the manual /compact status override; compaction status is now driven entirely by lifecycle events.
- Removed the "graceful stub" comments from compaction UI helpers now that backend support has landed.

## Verification
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml
- pnpm lint
- pnpm build

## Notes
Manual /compact remains dependent on the upstream AgentSession::checkpoint() implementation. In iron-core v0.1.32 that method is currently unimplemented, but when it is implemented it should emit the same lifecycle events used here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic compaction status tracking via backend event notifications
  * MCP compaction lifecycle event support with started, finished, and failed states
  * Token count updates now include compact threshold information

* **Documentation**
  * Updated descriptions for compaction result rendering and classification behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->