### PR TITLE
feat(config): add profile and prompt management

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Comment audit output
         if: always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/openspec/changes/add-config-management-ui/.openspec.yaml
+++ b/openspec/changes/add-config-management-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/add-config-management-ui/design.md
+++ b/openspec/changes/add-config-management-ui/design.md
@@ -2,7 +2,7 @@
 
 AgentIron is a Tauri 2 and SolidJS desktop client over shared `iron-core` configuration. The application already opens the platform-default core `ConfigStore`, but its UI exposes only provider, model, MCP, skill, and desktop settings. The Agents sidebar entry is inert, profile and prompt management commands do not exist, and the current provider settings path can return persisted API keys to JavaScript.
 
-`iron-core` v0.1.34 provides `ConfigManagementService`, typed agent-profile and stored-prompt contracts, secret-safe credential summaries and mutations, delete-impact queries, per-record diagnostics, and non-destructive seeding for the ordinary shipped `explore`, `plan`, and `apply` profiles. AgentIron should adapt those contracts rather than reproduce schema, normalization, reference, or seed logic.
+`iron-core` v0.1.35 provides `ConfigManagementService`, typed agent-profile and stored-prompt contracts, secret-safe credential summaries and mutations, delete-impact queries, per-record diagnostics, and non-destructive seeding for the ordinary shipped `explore`, `plan`, and `apply` profiles. AgentIron should adapt those contracts rather than reproduce schema, normalization, reference, or seed logic.
 
 The core store is shared with CLI and headless consumers. AgentIron therefore cannot assume that records remain unchanged while a screen is open or that all records were created by this UI. Existing migration completion is represented by a fake profile record, which would leak into typed profile diagnostics and must move to a core metadata primitive.
 

--- a/openspec/changes/add-config-management-ui/design.md
+++ b/openspec/changes/add-config-management-ui/design.md
@@ -1,0 +1,122 @@
+## Context
+
+AgentIron is a Tauri 2 and SolidJS desktop client over shared `iron-core` configuration. The application already opens the platform-default core `ConfigStore`, but its UI exposes only provider, model, MCP, skill, and desktop settings. The Agents sidebar entry is inert, profile and prompt management commands do not exist, and the current provider settings path can return persisted API keys to JavaScript.
+
+`iron-core` v0.1.34 provides `ConfigManagementService`, typed agent-profile and stored-prompt contracts, secret-safe credential summaries and mutations, delete-impact queries, per-record diagnostics, and non-destructive seeding for the ordinary shipped `explore`, `plan`, and `apply` profiles. AgentIron should adapt those contracts rather than reproduce schema, normalization, reference, or seed logic.
+
+The core store is shared with CLI and headless consumers. AgentIron therefore cannot assume that records remain unchanged while a screen is open or that all records were created by this UI. Existing migration completion is represented by a fake profile record, which would leak into typed profile diagnostics and must move to a core metadata primitive.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose typed, graphical CRUD for agent profiles and stored prompts in the existing Agents workspace.
+- Keep the frontend independent of raw core schema JSON and schema-version rules.
+- Seed core-owned shipped profiles on first run without overwriting edits or recreating deliberate deletions.
+- Prevent AgentIron from knowingly leaving no valid profile and provide explicit recovery after external deletion or corruption.
+- Manage provider credentials without returning persisted secret material to JavaScript.
+- Block shared configuration consistently when secure core initialization fails.
+- Establish frontend component-integration testing around a mocked Tauri command boundary.
+
+**Non-Goals:**
+
+- Applying or switching profiles in chat sessions.
+- Stored-prompt preview, execution, automation, or scheduling.
+- A terminal UI or a general-purpose raw ConfigDb editor.
+- Editing upstream-owned provider protocol profiles.
+- Live database watching or cross-process optimistic concurrency in `iron-core`.
+- Raw repair of malformed core records.
+- Full packaged-desktop end-to-end testing.
+
+## Decisions
+
+### 1. Use one typed backend boundary for core-owned management
+
+A dedicated Tauri command module will construct or access `ConfigManagementService` through managed core configuration state. It will expose serializable DTOs for profile entries, prompt entries, credential summaries, diagnostics, mutation results, seed reports, and delete impacts. DTO conversion will be explicit; frontend payloads will not contain arbitrary schema-versioned JSON.
+
+Alternative considered: call lower-level `ConfigStore` record APIs. This would duplicate validation, normalized prompt identity, reference, and credential-redaction rules in AgentIron and make schema evolution a frontend concern.
+
+### 2. Place profiles and prompts in the existing Agents workspace
+
+The dormant Agents navigation item will open a workspace with Profiles and Prompts sections. Credentials remain in Settings > Providers because credentials describe provider readiness rather than agent identity. The workspace will use list-and-editor interactions with explicit Save and Cancel actions instead of persisting partial state on each input event.
+
+Alternative considered: add all three capabilities as Settings sections. This hides the primary agent-configuration concepts among desktop settings and leaves the existing Agents navigation without purpose.
+
+### 3. Delegate shipped profile definitions and seed state to iron-core
+
+During shared-config initialization, AgentIron will invoke the core `FirstRunOnly` default-profile seed operation. Core remains the source of the `explore`, `plan`, and `apply` payloads and durable seed marker. Seeded records are ordinary editable and deletable profiles; AgentIron will not branch on their IDs or names.
+
+AgentIron will reject a profile deletion when its latest loaded delete impact and a backend recheck show that the operation would leave zero valid profiles. Malformed records do not count as valid profiles. If startup or refresh observes zero valid profiles because another consumer changed the shared store, the Agents workspace will enter a blocking recovery state with an explicit Restore Default Profiles action backed by core `RestoreMissing` behavior.
+
+This is an AgentIron operational invariant, not a claim that AgentIron can transactionally constrain every external ConfigDb client. A failed or stale deletion will be reported and followed by a refresh.
+
+Alternative considered: silently restore defaults whenever none remain. That would violate core's deliberate deletion-preservation semantics and surprise users who intentionally removed shipped records.
+
+### 4. Move migration completion out of the profile namespace
+
+The existing `agentiron.migration.v1` fake profile marker will be replaced by durable core metadata or a domain-scoped core setting. Initialization will recognize the old marker, record equivalent metadata, and remove only that known migration record after successful conversion. Normal profile listing will not hide records based on name patterns.
+
+Alternative considered: filter the marker from profile results. This would preserve namespace pollution, reserve an undocumented profile name, and conceal malformed data from other shared-store clients.
+
+### 5. Preserve unknown references and surface typed diagnostics
+
+The profile editor will present known providers, models, tools, and skills as suggestions while preserving valid unknown identifiers received from core. Unknown machine-local references will be shown as needs-attention diagnostics rather than discarded. Malformed or unsupported records will appear as diagnostic rows that can be inspected and deleted through typed operations, but raw JSON repair is out of scope.
+
+Alternative considered: restrict editors to AgentIron's current static catalogs. Shared profiles can validly reference tools, skills, or providers available to another runtime, so such restriction would make portable configuration lossy.
+
+### 6. Keep destructive operations explicit and non-cascading
+
+Before deletion, AgentIron will request core-owned delete-impact information. Referenced profiles or prompts will not be silently cascaded, reassigned, or unassigned. The UI will identify dependents and require users to resolve references before retrying deletion. Provider configuration and provider credential deletion remain independent operations.
+
+Alternative considered: cascade profile deletion into prompt updates. Hidden rewriting is risky in a shared store and obscures core referential-integrity errors.
+
+### 7. Treat stored IDs as identity and names as editable labels
+
+Prompt and profile records retain stable core IDs across edits and renames. Prompt normalized handles and collision rules come from core. The frontend may display immediate validation hints, but the backend result remains authoritative. A prompt has zero or one profile assignment, matching the core contract.
+
+### 8. Never hydrate saved API keys into frontend state
+
+Provider loading will return credential metadata and effective authentication status, never a persisted API-key value. The existing API-key input becomes a write-only field with Add or Replace labeling based on credential status. Set/replace and delete use dedicated typed commands. OAuth connection and status behavior remains intact, and the UI explains API-key precedence when both modes exist.
+
+Alternative considered: preserve whole-provider JSON persistence for compatibility. That keeps secrets in long-lived frontend state and makes clearing an input ambiguous with deleting a credential.
+
+### 9. Block all shared configuration after encryption initialization failure
+
+If core configuration cannot initialize its credential encryption key, AgentIron will not expose partial profile, prompt, provider, or credential management. The shared configuration surfaces will display an actionable error describing keyring or `AGENTIRON_CONFIG_ENCRYPTION_KEY` remediation without including secret material. Desktop-only settings may remain available if their existing initialization path is independent.
+
+### 10. Refresh at defined boundaries rather than watching the database
+
+Management state will refresh when the workspace is entered, after every successful mutation, after recovery, and when the user requests refresh. Mutation conflicts or stale references will trigger an error and refresh. Unsaved editor state will not be silently replaced; the user must confirm discard before an entry refresh that would overwrite it.
+
+Alternative considered: filesystem or SQLite watching. Cross-process ordering and partially committed state require a core-level synchronization design beyond this issue.
+
+### 11. Add Solid component-integration tests with mocked commands
+
+The frontend will add a Vite-compatible test runner, Solid component testing utilities, and a DOM environment. Tests will render real components and providers while mocking the typed command module rather than mocking Tauri globally in each test. Coverage will include navigation, loading, explicit save/cancel, validation, conflicts, zero-profile recovery, credential redaction and mutation, encryption failure, and refresh behavior.
+
+Rust tests will cover DTO serialization, command mapping, seed/recovery mapping, last-valid-profile enforcement, delete conflicts, diagnostics, and proof that credential responses omit secrets. Packaged Tauri end-to-end automation remains out of scope.
+
+## Risks / Trade-offs
+
+- **Risk: AgentIron cannot globally enforce the nonzero-profile invariant against other processes.** -> Recheck before AgentIron deletion, refresh after mutations, and block normal management behind explicit recovery when zero valid profiles are observed.
+- **Risk: DTOs drift from upstream core types.** -> Keep DTO conversion centralized and cover every variant with Rust serialization tests.
+- **Risk: migration-marker conversion could rerun an old migration.** -> Record new metadata before deleting the known legacy marker and retain idempotency tests.
+- **Risk: unknown references make forms harder to represent.** -> Use suggestion controls that retain custom values and render diagnostics separately from structural validation.
+- **Risk: replacing credential persistence changes existing provider form behavior.** -> Preserve provider configuration independently, migrate existing keys through the established core credential store, and test API-key and OAuth precedence states.
+- **Risk: component tests overfit presentation markup.** -> Assert accessible roles, labels, state transitions, and command interactions rather than CSS classes or internal component structure.
+
+## Migration Plan
+
+1. Add frontend test infrastructure and establish the mocked command boundary.
+2. Replace the legacy profile marker with core metadata through an idempotent migration.
+3. Add typed management DTOs, Tauri commands, and Rust adapter tests.
+4. Invoke core first-run profile seeding during secure shared-config initialization.
+5. Add Agents workspace navigation, profile management, prompt management, diagnostics, and recovery.
+6. Replace API-key hydration and whole-object secret persistence with typed credential commands in Providers settings.
+7. Add component-integration coverage and run all Rust and frontend checks.
+
+Rollback may remove the new UI and command registrations without deleting core records. Seeded profiles are ordinary shared records and remain usable by other clients. The migrated metadata and removed legacy marker remain valid; rollback must not recreate the fake profile marker or move secrets back into frontend-visible provider JSON.
+
+## Open Questions
+
+No proposal-blocking questions remain. Profile selection for new chats and packaged desktop end-to-end testing are explicit follow-up topics.

--- a/openspec/changes/add-config-management-ui/proposal.md
+++ b/openspec/changes/add-config-management-ui/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+AgentIron cannot currently manage the agent profiles, stored prompts, and provider credentials held in the shared `iron-core` configuration store. Issue #54 needs a graphical management surface that remains a thin, secret-safe adapter over core-owned typed contracts and gives users a recoverable, tested configuration experience.
+
+## What Changes
+
+- Activate the existing Agents workspace with graphical editors for agent profiles and stored prompts.
+- Seed the ordinary `iron-core` shipped profiles (`explore`, `plan`, and `apply`) on first run and prevent AgentIron operations from knowingly leaving the shared store without a valid profile.
+- Provide explicit recovery through the core restore-missing-defaults operation when external changes leave no valid profiles.
+- Add typed Tauri adapters for profile, prompt, delete-impact, diagnostics, and credential-management operations without exposing raw schema JSON to frontend code.
+- Replace saved API-key roundtripping with explicit secret-safe set, replace, and delete operations in Settings > Providers.
+- Block all shared configuration management with an actionable, secret-safe error when core credential encryption initialization fails.
+- Add frontend component-integration tests for navigation, forms, validation, mutation flows, recovery, conflicts, redaction, and error states.
+- Keep profile application to chats, prompt preview/execution, live database watching, terminal UI, automation tasks, and scheduling out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-profile-management-ui`: Graphical agent-profile listing, editing, diagnostics, first-run seeding, nonzero-profile protection, and explicit recovery.
+- `stored-prompt-management-ui`: Graphical stored-prompt CRUD, stable identity, normalized-name conflicts, profile assignment, diagnostics, and delete-impact handling.
+- `provider-credential-management-ui`: Secret-safe provider API-key and OAuth credential status management within the existing Providers settings surface.
+
+### Modified Capabilities
+
+- `persistent-config-ownership`: Classify agent profiles and stored prompts as shared core-owned configuration and define blocking behavior when shared configuration cannot initialize securely.
+
+## Impact
+
+- New typed Tauri command adapters over `iron_core::management::ConfigManagementService` and core default-profile seeding APIs.
+- Agents navigation, workspace components, frontend command types, and shared configuration state management.
+- Existing Providers settings and credential mutation flows; saved API keys will no longer be returned to JavaScript.
+- Existing shared-config initialization and migration-marker handling.
+- Frontend development dependencies, test configuration, test scripts, and CI verification.
+- Rust adapter tests plus Solid component-integration tests with mocked Tauri command boundaries.

--- a/openspec/changes/add-config-management-ui/specs/agent-profile-management-ui/spec.md
+++ b/openspec/changes/add-config-management-ui/specs/agent-profile-management-ui/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Agents workspace SHALL expose agent-profile management
+AgentIron SHALL activate the Agents workspace and provide graphical listing, creation, editing, and deletion of core-owned agent profiles through typed backend commands.
+
+#### Scenario: User opens profile management
+- **WHEN** the user selects Agents and opens Profiles
+- **THEN** AgentIron displays valid profile entries and per-record diagnostics returned by the backend
+- **AND** the frontend does not parse raw ConfigDb profile JSON
+
+#### Scenario: User saves a profile
+- **WHEN** the user explicitly saves a structurally valid profile form
+- **THEN** AgentIron sends a typed profile mutation retaining the stable profile ID for edits
+- **AND** refreshes profile state from the backend after success
+
+#### Scenario: User cancels profile edits
+- **WHEN** the user cancels a dirty profile form
+- **THEN** AgentIron discards the unsaved form state
+- **AND** does not issue a profile mutation
+
+### Requirement: AgentIron SHALL use core-owned shipped profile seeding
+AgentIron SHALL invoke the `iron-core` first-run seed operation for the ordinary shipped `explore`, `plan`, and `apply` profiles during secure shared-config initialization and SHALL NOT define or overwrite those profile payloads locally.
+
+#### Scenario: Shared configuration starts for the first time
+- **WHEN** shared configuration initializes successfully and the core seed marker is absent
+- **THEN** AgentIron invokes core first-run profile seeding
+- **AND** presents the resulting ordinary profile records without treating their names or IDs as runtime modes
+
+#### Scenario: User edited or deleted a shipped profile
+- **WHEN** normal startup occurs after first-run seeding
+- **THEN** AgentIron does not overwrite an edited shipped profile
+- **AND** does not silently recreate a deliberately deleted shipped profile
+
+### Requirement: AgentIron SHALL prevent known zero-profile states
+AgentIron SHALL reject profile deletions that would knowingly leave zero valid profiles and SHALL block normal profile and prompt management behind explicit recovery whenever the refreshed shared store contains zero valid profiles.
+
+#### Scenario: User attempts to delete the last valid profile
+- **WHEN** exactly one valid profile remains and the user requests its deletion
+- **THEN** AgentIron rejects the deletion
+- **AND** explains that at least one valid profile must remain
+
+#### Scenario: Malformed records remain beside one valid profile
+- **WHEN** one valid profile and any number of malformed profile records exist
+- **AND** the user requests deletion of the valid profile
+- **THEN** AgentIron treats the request as deletion of the last valid profile
+- **AND** rejects it
+
+#### Scenario: External client removes all valid profiles
+- **WHEN** startup or refresh reports zero valid profiles
+- **THEN** AgentIron blocks normal profile and prompt management
+- **AND** offers an explicit Restore Default Profiles recovery action
+
+#### Scenario: User restores default profiles
+- **WHEN** the user invokes recovery
+- **THEN** AgentIron calls the core restore-missing-defaults operation
+- **AND** refreshes the workspace after the operation succeeds
+- **AND** does not overwrite any existing valid shipped profile record
+
+### Requirement: Profile management SHALL preserve portable references
+AgentIron SHALL preserve structurally valid provider, model, tool, and skill identifiers that are unknown to the current AgentIron runtime and SHALL present core diagnostics without making machine-local availability a prerequisite for editing.
+
+#### Scenario: Profile contains an unknown tool or skill
+- **WHEN** AgentIron loads a valid profile containing a tool or skill identifier absent from its current catalog
+- **THEN** the editor retains the identifier
+- **AND** displays the applicable needs-attention diagnostic
+
+#### Scenario: Profile contains an unavailable provider or model
+- **WHEN** AgentIron loads a valid profile containing an unavailable provider or model reference
+- **THEN** the editor preserves the reference
+- **AND** does not silently replace it with a local selection
+
+### Requirement: Profile diagnostics SHALL remain visible and actionable
+AgentIron SHALL display malformed and unsupported profile diagnostics returned by core and SHALL NOT hide records by reserved-name conventions.
+
+#### Scenario: Core reports a malformed profile
+- **WHEN** profile loading returns a diagnostic for a malformed or unsupported record
+- **THEN** AgentIron displays a diagnostic row with the core-provided explanation
+- **AND** does not count the record as a valid profile
+
+#### Scenario: User deletes a malformed record
+- **WHEN** core permits deletion of a malformed profile record and the user confirms deletion
+- **THEN** AgentIron deletes it through a typed backend operation
+- **AND** refreshes diagnostics after success
+
+### Requirement: Profile deletion SHALL honor core dependency impacts
+AgentIron SHALL query and present core-owned dependency impacts before profile deletion and SHALL NOT cascade, reassign, or unassign dependent records automatically.
+
+#### Scenario: Prompt references a profile
+- **WHEN** the user requests deletion of a profile referenced by one or more stored prompts
+- **THEN** AgentIron identifies the dependent prompts
+- **AND** blocks deletion until the references are resolved
+
+#### Scenario: Profile has no dependencies and is not the last valid profile
+- **WHEN** the user confirms deletion of an unreferenced profile and another valid profile remains
+- **THEN** AgentIron deletes the profile through the typed backend operation
+- **AND** refreshes profile and prompt state

--- a/openspec/changes/add-config-management-ui/specs/persistent-config-ownership/spec.md
+++ b/openspec/changes/add-config-management-ui/specs/persistent-config-ownership/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Shared runtime config SHALL move behind iron-core APIs
+AgentIron SHALL treat agent profiles, stored prompts, provider config, provider credentials, default model, custom models, MCP servers, skills settings, and handoff API/storage as shared runtime state owned by `iron-core`.
+
+#### Scenario: AgentIron opens shared core config
+- **WHEN** AgentIron initializes shared runtime config
+- **THEN** AgentIron SHALL use the platform-default `iron-core` config path through `ConfigStore::open()` unless a concrete platform blocker requires a documented exception
+- **AND** AgentIron SHALL NOT use an AgentIron GUI-specific core config path by default
+
+#### Scenario: AgentIron reads shared runtime config
+- **WHEN** AgentIron needs agent profiles, stored prompts, provider config, credentials, default model, custom models, MCP server definitions, skills settings, or handoff state
+- **THEN** AgentIron SHALL read that state through backend commands backed by typed `iron-core` APIs
+- **AND** the frontend SHALL NOT read that state directly from app-owned SQL tables or parse raw core record JSON
+
+#### Scenario: AgentIron updates shared runtime config
+- **WHEN** the user updates agent profiles, stored prompts, provider config, credentials, default model, custom models, MCP server definitions, skills settings, or handoff state
+- **THEN** AgentIron SHALL persist the update through typed `iron-core` APIs
+- **AND** AgentIron SHALL NOT write directly to the core config database with frontend SQL or arbitrary schema-versioned payloads
+
+#### Scenario: CLI or headless mode uses shared config
+- **WHEN** CLI/headless and AgentIron run against the same core config store
+- **THEN** they SHALL observe the same agent profiles, stored prompts, provider config, credentials, default model, custom models, MCP servers, skills settings, and handoff state
+
+#### Scenario: Credential encryption key is unavailable
+- **WHEN** AgentIron cannot access or create the `iron-core` credential encryption key during shared-config initialization
+- **THEN** AgentIron SHALL block all shared configuration loading and management rather than expose partially initialized profiles, prompts, providers, or credentials
+- **AND** AgentIron SHALL display a helpful error that explains how to provide `AGENTIRON_CONFIG_ENCRYPTION_KEY` or fix OS keyring access
+- **AND** the error SHALL NOT expose credential material

--- a/openspec/changes/add-config-management-ui/specs/provider-credential-management-ui/spec.md
+++ b/openspec/changes/add-config-management-ui/specs/provider-credential-management-ui/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Provider settings SHALL expose secret-safe credential status
+AgentIron SHALL display provider credential kind, configured status, OAuth status, and other core-approved metadata without returning or rendering persisted secret material.
+
+#### Scenario: Provider has a saved API key
+- **WHEN** provider settings load a credential summary for an API-key credential
+- **THEN** the UI indicates that an API key is configured
+- **AND** neither the backend response nor frontend state contains the saved API-key value
+
+#### Scenario: Provider has OAuth credentials
+- **WHEN** provider settings load OAuth credential status
+- **THEN** the UI displays connection and effective-authentication status using secret-safe metadata
+- **AND** does not expose access tokens, refresh tokens, or bearer credentials
+
+### Requirement: API-key mutation SHALL use explicit typed operations
+AgentIron SHALL add, replace, and delete API-key credentials through dedicated typed core-backed commands rather than persisting secret values in whole-provider settings payloads.
+
+#### Scenario: User adds an API key
+- **WHEN** no API-key credential exists and the user submits a non-empty API key
+- **THEN** AgentIron invokes the typed set-credential command
+- **AND** clears the write-only input after success
+- **AND** refreshes credential status
+
+#### Scenario: User replaces an API key
+- **WHEN** an API-key credential exists and the user submits a replacement
+- **THEN** AgentIron labels the operation as replacement
+- **AND** invokes the typed set-credential command without loading the previous key
+
+#### Scenario: User deletes an API key
+- **WHEN** the user confirms API-key deletion
+- **THEN** AgentIron invokes the typed delete-credential command
+- **AND** refreshes provider credential and readiness status
+
+### Requirement: Provider configuration and credentials SHALL have independent lifecycles
+AgentIron SHALL NOT implicitly delete a provider credential when provider configuration is removed and SHALL NOT remove provider configuration when a credential is deleted.
+
+#### Scenario: User removes provider configuration
+- **WHEN** the user removes or disables a provider configuration
+- **THEN** AgentIron preserves any stored provider credential
+- **AND** makes credential removal a separate explicit action
+
+#### Scenario: User removes a credential
+- **WHEN** the user deletes a provider credential
+- **THEN** AgentIron preserves non-secret provider configuration
+- **AND** updates readiness to reflect the missing credential
+
+### Requirement: Effective authentication mode SHALL be understandable
+AgentIron SHALL show which authentication mode is effective when a provider supports both API-key and OAuth credentials and SHALL preserve core-owned precedence semantics.
+
+#### Scenario: API key and OAuth are both configured
+- **WHEN** core status reports both credential modes and API-key precedence
+- **THEN** AgentIron identifies API key as the effective mode
+- **AND** explains that the OAuth connection remains stored but is not currently used
+
+#### Scenario: API key is removed while OAuth remains connected
+- **WHEN** the user deletes the API key and OAuth status remains usable
+- **THEN** AgentIron refreshes status
+- **AND** displays OAuth as the effective mode
+
+### Requirement: Credential failures SHALL remain secret-safe
+AgentIron SHALL display actionable credential mutation and status errors without logging, retaining, or rendering submitted or persisted secret values.
+
+#### Scenario: API-key mutation fails
+- **WHEN** setting or deleting an API key fails
+- **THEN** AgentIron displays a provider-specific error without secret material
+- **AND** does not report the failed mutation as configured

--- a/openspec/changes/add-config-management-ui/specs/stored-prompt-management-ui/spec.md
+++ b/openspec/changes/add-config-management-ui/specs/stored-prompt-management-ui/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Agents workspace SHALL expose stored-prompt management
+AgentIron SHALL provide graphical listing, creation, editing, renaming, profile assignment, and deletion of core-owned stored prompts through typed backend commands.
+
+#### Scenario: User opens prompt management
+- **WHEN** the user selects Agents and opens Prompts while at least one valid profile exists
+- **THEN** AgentIron displays valid prompt entries and per-record diagnostics returned by the backend
+- **AND** the frontend does not parse raw ConfigDb prompt JSON
+
+#### Scenario: User creates a stored prompt
+- **WHEN** the user explicitly saves a valid new prompt form
+- **THEN** AgentIron creates the prompt through a typed backend command
+- **AND** refreshes prompt state after success
+
+#### Scenario: User cancels prompt edits
+- **WHEN** the user cancels a dirty prompt form
+- **THEN** AgentIron discards unsaved changes
+- **AND** does not issue a prompt mutation
+
+### Requirement: Stored-prompt identity SHALL remain core-owned and stable
+AgentIron SHALL preserve stable prompt IDs across edits and renames and SHALL defer normalized handle generation and collision enforcement to `iron-core`.
+
+#### Scenario: User renames a prompt
+- **WHEN** the user saves a new display name for an existing prompt
+- **THEN** AgentIron uses the typed core rename or save operation
+- **AND** retains the prompt's stable ID
+
+#### Scenario: Normalized prompt name collides
+- **WHEN** core rejects a create or rename because its normalized handle collides case-insensitively with another prompt
+- **THEN** AgentIron displays the conflict on the name field
+- **AND** retains the user's unsaved form values for correction
+
+### Requirement: Stored prompts SHALL support optional profile assignment
+AgentIron SHALL allow a stored prompt to reference zero or one valid agent profile by stable profile ID.
+
+#### Scenario: User assigns a profile
+- **WHEN** the user selects a profile and saves a prompt
+- **THEN** AgentIron persists the selected stable profile ID through the typed prompt mutation
+
+#### Scenario: User removes a profile assignment
+- **WHEN** the user clears a prompt's profile assignment and saves
+- **THEN** AgentIron persists the prompt without a profile reference
+
+#### Scenario: Assigned profile is unavailable
+- **WHEN** a prompt load diagnostic reports a missing or malformed referenced profile
+- **THEN** AgentIron preserves the unresolved reference for display
+- **AND** identifies the prompt as needing attention
+
+### Requirement: Prompt deletion SHALL honor core dependency impacts
+AgentIron SHALL present core-owned dependency impacts before prompt deletion and SHALL NOT cascade deletion into future automation or scheduling records.
+
+#### Scenario: Prompt has dependent records
+- **WHEN** core reports that another record references the prompt
+- **THEN** AgentIron displays those dependencies
+- **AND** blocks deletion until the references are resolved
+
+#### Scenario: Prompt has no dependent records
+- **WHEN** the user confirms deletion and core reports no blocking references
+- **THEN** AgentIron deletes the prompt through a typed backend operation
+- **AND** refreshes prompt state
+
+### Requirement: Prompt diagnostics SHALL remain visible and actionable
+AgentIron SHALL display malformed, unsupported, and needs-attention prompt diagnostics returned by core without attempting raw JSON repair.
+
+#### Scenario: Core reports a malformed prompt
+- **WHEN** prompt loading returns a malformed or unsupported record diagnostic
+- **THEN** AgentIron displays the diagnostic and excludes the record from the normal editor
+- **AND** offers deletion when the typed backend permits it
+
+#### Scenario: Prompt references unknown skills
+- **WHEN** a valid prompt contains requested skills unavailable in the current AgentIron catalog
+- **THEN** AgentIron preserves those skill identifiers
+- **AND** displays the applicable needs-attention diagnostic

--- a/openspec/changes/add-config-management-ui/tasks.md
+++ b/openspec/changes/add-config-management-ui/tasks.md
@@ -1,0 +1,68 @@
+## 1. Frontend Test Foundation
+
+- [x] 1.1 Add a Vite-compatible frontend test runner, Solid component testing utilities, DOM environment, and `pnpm test` scripts.
+- [x] 1.2 Add shared test rendering helpers for application providers and a reusable mock for the typed Tauri command module.
+- [x] 1.3 Add a smoke component test proving Solid rendering, user interaction, and mocked command responses work in CI.
+
+## 2. Shared Configuration Initialization and Migration
+
+- [x] 2.1 Replace the `agentiron.migration.v1` fake profile marker with durable core metadata while preserving idempotent migration completion.
+- [x] 2.2 Add migration tests for legacy-marker conversion, metadata-first write ordering, repeated startup, and preservation of unrelated profile records.
+- [x] 2.3 Invoke the core `FirstRunOnly` shipped-profile seed operation after secure shared-config initialization.
+- [x] 2.4 Map encryption-key initialization failures to one actionable secret-safe shared-config error that blocks profile, prompt, provider, and credential management.
+- [x] 2.5 Add initialization tests for first-run seeding, preservation of edited or deleted shipped profiles, and encryption failure.
+
+## 3. Typed Backend Management Boundary
+
+- [x] 3.1 Add serializable DTOs for profile entries, prompt entries, credential summaries, load diagnostics, delete impacts, seed reports, and typed mutation errors.
+- [x] 3.2 Add Tauri commands over `ConfigManagementService` for profile list/get/save/delete and profile delete-impact queries.
+- [x] 3.3 Add Tauri commands over `ConfigManagementService` for prompt list/get/create/save/rename/delete and prompt delete-impact queries.
+- [x] 3.4 Add Tauri commands for credential summaries and typed API-key set/replace/delete operations without secret-bearing response fields.
+- [x] 3.5 Add a recovery command backed by core `RestoreMissing` default-profile seeding.
+- [x] 3.6 Recheck valid-profile count and dependency impacts at profile deletion time so AgentIron does not knowingly delete the last valid profile or a referenced profile.
+- [x] 3.7 Register the management commands with Tauri and expose typed frontend wrappers in the shared command module.
+- [x] 3.8 Add Rust tests covering DTO variants, serialization, diagnostics, stable IDs, delete conflicts, last-valid-profile rejection, recovery mapping, and credential redaction.
+
+## 4. Frontend Management State and Navigation
+
+- [x] 4.1 Extend application navigation so the existing Agents sidebar item opens an Agents workspace with Profiles and Prompts sections.
+- [x] 4.2 Add shared management state for loading profiles, prompts, diagnostics, credential summaries, mutation errors, and refresh status through typed commands.
+- [x] 4.3 Refresh management state on workspace entry, explicit refresh, successful mutation, and recovery while protecting dirty editors from silent replacement.
+- [x] 4.4 Add blocking shared-config error presentation for encryption initialization failures and a zero-valid-profile recovery state.
+- [x] 4.5 Add component-integration tests for Agents navigation, section switching, loading, refresh, dirty-state protection, encryption failure, and recovery routing.
+
+## 5. Agent Profile Management UI
+
+- [x] 5.1 Build profile list and diagnostic-row presentation that distinguishes valid, needs-attention, malformed, and unsupported records.
+- [x] 5.2 Build explicit Save and Cancel profile forms for name, provider/model context, tool filter, skill filter, approval policy, and identity prompt.
+- [x] 5.3 Preserve unknown provider, model, tool, and skill identifiers while presenting known catalog entries as suggestions.
+- [x] 5.4 Present core validation and mutation errors on the relevant profile fields without discarding unsaved input.
+- [x] 5.5 Add profile delete confirmation with dependent-record details and last-valid-profile protection.
+- [x] 5.6 Add explicit Restore Default Profiles interaction using the typed recovery command.
+- [x] 5.7 Add component-integration tests for profile creation, editing, cancellation, unknown references, diagnostics, conflicts, deletion, and default restoration.
+
+## 6. Stored Prompt Management UI
+
+- [x] 6.1 Build prompt list and diagnostic-row presentation for valid, needs-attention, malformed, and unsupported records.
+- [x] 6.2 Build explicit Save and Cancel prompt forms for display name, instructions, requested skills, and optional stable profile assignment.
+- [x] 6.3 Preserve stable prompt IDs across edits and renames and map normalized-handle collisions to the name field.
+- [x] 6.4 Preserve unknown requested-skill and missing-profile references while displaying core diagnostics.
+- [x] 6.5 Add prompt delete confirmation with dependent-record details and no automatic cascading or reassignment.
+- [x] 6.6 Add component-integration tests for prompt creation, editing, rename collisions, profile assignment, unknown references, diagnostics, and deletion conflicts.
+
+## 7. Secret-Safe Provider Credential UI
+
+- [x] 7.1 Remove persisted API-key values from provider settings responses, frontend provider state, and whole-provider mutation payloads.
+- [x] 7.2 Update Settings > Providers to render secret-safe credential and effective-authentication status from typed summaries.
+- [x] 7.3 Replace the API-key editor with a write-only Add or Replace flow backed by the typed credential command.
+- [x] 7.4 Add explicit API-key deletion without removing provider configuration and preserve credentials when provider configuration is removed.
+- [x] 7.5 Preserve OAuth connect, disconnect, refresh, and precedence behavior while explaining the effective mode when OAuth and API key coexist.
+- [x] 7.6 Audit logs, errors, events, and frontend state to ensure submitted and persisted secret values are not retained or rendered.
+- [x] 7.7 Add component-integration tests for redacted status, add, replace, delete, independent provider lifecycle, OAuth coexistence, and secret-safe failures.
+
+## 8. Verification
+
+- [x] 8.1 Run frontend component tests and resolve all failures.
+- [x] 8.2 Run `cargo fmt -- --check`, `cargo clippy -- -D warnings`, and `cargo test` in `src-tauri`.
+- [x] 8.3 Run `pnpm lint` and `pnpm build`.
+- [x] 8.4 Validate the OpenSpec change in strict mode and confirm every specified scenario has implementation or automated coverage.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "serve": "vite preview",
     "tauri": "tauri",
     "lint": "eslint src/",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "license": "Apache-2.0",
   "pnpm": {
@@ -19,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.3.2",
+    "@tailwindcss/vite": "^4.3.3",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -31,10 +33,11 @@
     "solid-icons": "^1.2.0",
     "solid-js": "^1.9.14",
     "solid-transition-group": "^0.3.0",
-    "tailwindcss": "^4.3.2",
+    "tailwindcss": "^4.3.3",
     "tinykeys": "^4.0.0"
   },
   "devDependencies": {
+    "@solidjs/testing-library": "^0.8.10",
     "@tauri-apps/cli": "^2.11.4",
     "@types/prismjs": "^1.26.6",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
@@ -42,9 +45,11 @@
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-solid": "^0.14.5",
+    "happy-dom": "^20.10.6",
     "prettier": "^3.9.5",
     "typescript": "~6.0.3",
-    "vite": "^8.1.4",
-    "vite-plugin-solid": "^2.11.12"
+    "vite": "^8.1.5",
+    "vite-plugin-solid": "^2.11.12",
+    "vitest": "^4.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@tailwindcss/vite':
-        specifier: ^4.3.2
-        version: 4.3.2(vite@8.1.4(jiti@2.7.0))
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
@@ -45,12 +45,15 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0(solid-js@1.9.14)
       tailwindcss:
-        specifier: ^4.3.2
-        version: 4.3.2
+        specifier: ^4.3.3
+        version: 4.3.3
       tinykeys:
         specifier: ^4.0.0
         version: 4.0.0
     devDependencies:
+      '@solidjs/testing-library':
+        specifier: ^0.8.10
+        version: 0.8.10(solid-js@1.9.14)
       '@tauri-apps/cli':
         specifier: ^2.11.4
         version: 2.11.4
@@ -72,6 +75,9 @@ importers:
       eslint-plugin-solid:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       prettier:
         specifier: ^3.9.5
         version: 3.9.5
@@ -79,11 +85,14 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.1.4
-        version: 8.1.4(jiti@2.7.0)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.12(solid-js@1.9.14)(vite@8.1.4(jiti@2.7.0))
+        version: 2.11.12(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
 
 packages:
 
@@ -155,6 +164,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -373,69 +386,82 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
-  '@tailwindcss/node@4.3.2':
-    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+  '@solidjs/testing-library@0.8.10':
+    resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      '@solidjs/router': '>=0.9.0'
+      solid-js: '>=1.0.0'
+    peerDependenciesMeta:
+      '@solidjs/router':
+        optional: true
 
-  '@tailwindcss/oxide-android-arm64@4.3.2':
-    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.2':
-    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.3.2':
-    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.2':
-    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
-    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
-    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
-    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
-    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
-    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
-    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -446,24 +472,24 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
-    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
-    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.3.2':
-    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/vite@4.3.2':
-    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
@@ -558,8 +584,15 @@ packages:
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -573,14 +606,29 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.64.0':
     resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
@@ -678,6 +726,35 @@ packages:
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -691,12 +768,27 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   babel-plugin-jsx-dom-expressions@0.40.7:
     resolution: {integrity: sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==}
@@ -736,12 +828,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -779,20 +879,34 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   electron-to-chromium@1.5.375:
     resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
-  enhanced-resolve@5.21.6:
-    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+  enhanced-resolve@5.24.2:
+    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -857,9 +971,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -917,6 +1038,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1094,6 +1219,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1128,6 +1257,10 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1155,6 +1288,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1175,6 +1311,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -1182,6 +1322,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1224,6 +1367,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   solid-icons@1.2.0:
     resolution: {integrity: sha512-yjQxWQMi9l19P5Af9vjsvalTMDFPDL4XD6etrUdNxNVhFp1bMYF0SFwUa5VYDfJ7u0SF3Qkz/F7BZxqcLUwklw==}
     peerDependencies:
@@ -1247,6 +1393,12 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1258,12 +1410,19 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  tailwindcss@4.3.2:
-    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -1272,6 +1431,10 @@ packages:
   tinykeys@4.0.0:
     resolution: {integrity: sha512-z5bQRQHL1PSx3lGOZEAMM2oKp0EBtn5T5f7HJnaKPOzk6vEH0wUPvdHLeQ7F4tmkek8AgoTQISUFmn/5SNF2xA==}
     engines: {node: '>=22'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1290,6 +1453,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1310,8 +1476,8 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite@8.1.4:
-    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1361,14 +1527,76 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1466,6 +1694,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -1660,73 +1890,80 @@ snapshots:
     dependencies:
       solid-js: 1.9.14
 
-  '@tailwindcss/node@4.3.2':
+  '@solidjs/testing-library@0.8.10(solid-js@1.9.14)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      solid-js: 1.9.14
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.6
+      enhanced-resolve: 5.24.2
       jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.3.2
+      tailwindcss: 4.3.3
 
-  '@tailwindcss/oxide-android-arm64@4.3.2':
+  '@tailwindcss/oxide-android-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.3.2':
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide@4.3.2':
+  '@tailwindcss/oxide@4.3.3':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.3.2
-      '@tailwindcss/oxide-darwin-arm64': 4.3.2
-      '@tailwindcss/oxide-darwin-x64': 4.3.2
-      '@tailwindcss/oxide-freebsd-x64': 4.3.2
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
-      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
-      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
-      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
-      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
-      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.2(vite@8.1.4(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))':
     dependencies:
-      '@tailwindcss/node': 4.3.2
-      '@tailwindcss/oxide': 4.3.2
-      tailwindcss: 4.3.2
-      vite: 8.1.4(jiti@2.7.0)
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
 
   '@tauri-apps/api@2.11.1': {}
 
@@ -1793,10 +2030,23 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1819,11 +2069,28 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/prismjs@1.26.6': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.1
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -1967,6 +2234,47 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -1980,11 +2288,21 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  assertion-error@2.0.1: {}
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -2025,9 +2343,15 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 26.1.1
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2058,16 +2382,24 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   electron-to-chromium@1.5.375: {}
 
-  enhanced-resolve@5.21.6:
+  enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  es-module-lexer@2.3.1: {}
 
   escalade@3.2.0: {}
 
@@ -2158,7 +2490,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2200,6 +2538,19 @@ snapshots:
   globals@14.0.0: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 26.1.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -2324,6 +2675,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2349,6 +2702,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.47: {}
+
+  obug@2.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2379,6 +2734,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
@@ -2393,9 +2750,17 @@ snapshots:
 
   prettier@3.9.5: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   punycode@2.3.1: {}
+
+  react-is@17.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -2438,6 +2803,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   solid-icons@1.2.0(solid-js@1.9.14):
     dependencies:
       solid-js: 1.9.14
@@ -2465,6 +2832,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
   strip-json-comments@3.1.1: {}
 
   style-to-object@1.0.14:
@@ -2475,9 +2846,13 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tailwindcss@4.3.2: {}
+  tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -2485,6 +2860,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinykeys@4.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -2499,6 +2876,8 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  undici-types@8.3.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2509,7 +2888,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.14)(vite@8.1.4(jiti@2.7.0)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@types/babel__core': 7.20.5
@@ -2517,12 +2896,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.14
       solid-refresh: 0.6.3(solid-js@1.9.14)
-      vite: 8.1.4(jiti@2.7.0)
-      vitefu: 1.1.3(vite@8.1.4(jiti@2.7.0))
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.1.4(jiti@2.7.0):
+  vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -2530,18 +2909,56 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitefu@1.1.3(vite@8.1.4(jiti@2.7.0)):
+  vitefu@1.1.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)):
     optionalDependencies:
-      vite: 8.1.4(jiti@2.7.0)
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
+
+  vitest@4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      happy-dom: 20.10.6
+    transitivePeerDependencies:
+      - msw
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  ws@8.21.1: {}
 
   yallist@3.1.1: {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -590,7 +590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -631,9 +631,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -832,7 +832,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -1061,9 +1061,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1296,7 +1296,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -1309,7 +1309,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1833,7 +1833,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -1933,7 +1933,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -2619,7 +2619,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "debugid",
  "rustc-hash",
  "serde",
@@ -2633,7 +2633,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "drm",
  "drm-fourcc",
  "gbm-sys",
@@ -2762,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da24fbda09ec01bca7cfa1797c0e520e75123bccb01dcdf9041f8aa65183bc2"
+checksum = "33ce01473d0fed9913c71114f0384807cdf584673424d093c102263645bf2a31"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -2925,7 +2925,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3016,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "grep-matcher"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+checksum = "f9417543f4870fc8f1c8e1af870afae2431007626d9e703fce6471c468d33847"
 dependencies = [
  "memchr",
 ]
@@ -3038,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "grep-searcher"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+checksum = "72348823a0eafc4bc2e9051064f28b5b42cc100b571b3a35d67918d711efcbc6"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3541,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3692,8 +3692,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iron-core"
-version = "0.1.34"
-source = "git+https://github.com/AgentIron/iron-core.git?tag=v0.1.34#ad387b2b1d8ac501f657127462a884e0e70bcc87"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9a40ada08d45e95e5a2dbdf1537b1827954777c3d0cafe2c8d84a245e388b8"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3736,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89419b49d98e55a3502486adeae2cfba19d5ff217fd52a26d277c248f6515b"
+checksum = "642263708851d386ff230f7540499f2d456e6d3887b25350c32add2ed9d44ea0"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -4034,7 +4035,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -4215,7 +4216,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cc",
  "convert_case 0.8.0",
  "cookie-factory",
@@ -4587,7 +4588,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -4617,7 +4618,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4801,7 +4802,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -4822,7 +4823,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -4854,7 +4855,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -4877,7 +4878,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -4887,7 +4888,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -4898,7 +4899,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -4911,7 +4912,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -4947,7 +4948,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -4963,7 +4964,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -4975,7 +4976,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -5005,7 +5006,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -5029,7 +5030,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5052,7 +5053,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -5063,7 +5064,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -5075,7 +5076,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -5106,7 +5107,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -5155,7 +5156,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -5440,7 +5441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
 dependencies = [
  "anyhow",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "libspa",
  "libspa-sys",
@@ -5499,7 +5500,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6121,7 +6122,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6162,7 +6163,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6240,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6252,9 +6253,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6398,7 +6399,7 @@ checksum = "a10ab966362319801f5e85ce5c6aeac69f0cf50936a31e888f5d004e9279f337"
 dependencies = [
  "aho-corasick",
  "arrayvec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "get-size2",
  "is-macro",
@@ -6417,7 +6418,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3b8436fb010636ea79ce545acc3e391296ef4e804f7cef336dd5f9c8a4aa3a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bstr",
  "compact_str",
  "get-size2",
@@ -6439,7 +6440,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c8860927bf42efdabb31ccb2ac9b8f98ee43897b45536f8023e217b158e49a4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "unicode-ident",
 ]
 
@@ -6480,7 +6481,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -6517,7 +6518,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6530,7 +6531,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6755,7 +6756,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6778,7 +6779,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -7288,7 +7289,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7317,7 +7318,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -7529,7 +7530,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7576,7 +7577,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -7592,7 +7593,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -8134,9 +8135,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
@@ -8347,7 +8348,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -8694,9 +8695,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -8807,7 +8808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46137f5bcc41a0f002ed14688e463665388a6f3a6662a12a8c315d4b8849791c"
 dependencies = [
  "async-trait",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cap-fs-ext",
  "cap-rand",
  "cap-std",
@@ -8950,7 +8951,7 @@ version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "semver",
@@ -8963,7 +8964,7 @@ version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "indexmap 2.14.0",
  "semver",
 ]
@@ -8987,7 +8988,7 @@ checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -9230,7 +9231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
 dependencies = [
  "anyhow",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
  "wit-parser",
@@ -9287,7 +9288,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -9299,7 +9300,7 @@ version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -9311,7 +9312,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9335,7 +9336,7 @@ version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "downcast-rs",
  "rustix 1.1.4",
  "wayland-backend",
@@ -9509,7 +9510,7 @@ version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8cfd3db2f05619c6f36f257d84327c11546e28d61e3a1c1220aaad553bc4b0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "thiserror 2.0.18",
  "tracing",
  "wasmtime",
@@ -10121,7 +10122,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "windows-sys 0.59.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-iron-core = { git = "https://github.com/AgentIron/iron-core.git", tag = "v0.1.34", features = ["embedded-python"] }
+iron-core = { version = "0.1.35", features = ["embedded-python"] }
 iron-providers = "0.2.13"
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -52,10 +52,37 @@ async fn build_provider(
             iron_providers::AuthStrategy::NoAuth,
         );
 
-        let runtime_config = if api_key.trim().is_empty() {
-            iron_providers::RuntimeConfig::none()
+        // Try the explicit API key first; if empty, resolve from the shared
+        // credential store so secret-safe typed commands work for local too.
+        let resolved_key = if !api_key.trim().is_empty() {
+            Some(api_key.to_string())
         } else {
-            iron_providers::RuntimeConfig::new(api_key)
+            match state
+                .credential_resolver
+                .resolve(
+                    &ProviderPromptContext {
+                        provider_slug: iron_core::provider_credential::domain::ProviderSlug::new(
+                            "local",
+                        ),
+                        model: model.to_string(),
+                        api_key: None,
+                    },
+                    None,
+                )
+                .await
+            {
+                Ok(resolved) => match resolved.provider_credential {
+                    iron_providers::ProviderCredential::ApiKey(k) => Some(k),
+                    _ => None,
+                },
+                Err(ProviderAuthError::NotConfigured(_)) => None,
+                Err(e) => return Err(credential_resolution_message(e)),
+            }
+        };
+
+        let runtime_config = match resolved_key {
+            Some(k) if !k.trim().is_empty() => iron_providers::RuntimeConfig::new(&k),
+            _ => iron_providers::RuntimeConfig::none(),
         };
 
         return iron_providers::ProviderConnection::from_profile(profile, runtime_config)

--- a/src-tauri/src/commands/config_management.rs
+++ b/src-tauri/src/commands/config_management.rs
@@ -11,7 +11,7 @@ use iron_core::profile::{
 };
 use iron_core::stored_prompt::{IdentityState, StoredPrompt};
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 
 use crate::core_config::CoreConfig;
 
@@ -622,14 +622,36 @@ fn service(config: &CoreConfig) -> ConfigManagementService {
     ConfigManagementService::new((*config.store).clone())
 }
 
+fn shared_config(app: &AppHandle) -> Result<State<'_, CoreConfig>, String> {
+    if let Some(config) = app.try_state::<CoreConfig>() {
+        return Ok(config);
+    }
+
+    let error = app
+        .state::<SharedConfigError>()
+        .lock()
+        .map_err(|e| e.to_string())?
+        .clone()
+        .unwrap_or_else(|| "Shared configuration is unavailable.".to_string());
+    Err(error)
+}
+
+fn shared_config_for_mutation(app: &AppHandle) -> Result<State<'_, CoreConfig>, MutationErrorDto> {
+    shared_config(app).map_err(|message| MutationErrorDto {
+        kind: "unavailable".to_string(),
+        message,
+        field: None,
+        referrers: Vec::new(),
+    })
+}
+
 // ============================================================================
 // Profile commands
 // ============================================================================
 
 #[tauri::command]
-pub async fn list_profiles(
-    config: State<'_, CoreConfig>,
-) -> Result<Vec<ManagedProfileRecordDto>, String> {
+pub async fn list_profiles(app: AppHandle) -> Result<Vec<ManagedProfileRecordDto>, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.list_profiles()
         .await
@@ -639,9 +661,10 @@ pub async fn list_profiles(
 
 #[tauri::command]
 pub async fn get_profile(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     id: String,
 ) -> Result<Option<ManagedProfileRecordDto>, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.get_profile(&id)
         .await
@@ -651,10 +674,11 @@ pub async fn get_profile(
 
 #[tauri::command]
 pub async fn save_profile(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     id: String,
     profile: AgentProfileDto,
 ) -> Result<(), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     let typed: AgentProfile = profile.try_into().map_err(|e: String| MutationErrorDto {
         kind: "validation".to_string(),
@@ -668,10 +692,8 @@ pub async fn save_profile(
 }
 
 #[tauri::command]
-pub async fn delete_profile(
-    config: State<'_, CoreConfig>,
-    id: String,
-) -> Result<(), MutationErrorDto> {
+pub async fn delete_profile(app: AppHandle, id: String) -> Result<(), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
 
     svc.delete_profile_with_policy(&id, ProfileDeletePolicy::RequireMinimumValid(1))
@@ -681,9 +703,10 @@ pub async fn delete_profile(
 
 #[tauri::command]
 pub async fn profile_impact(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     profileId: String,
 ) -> Result<DependencyImpactReportDto, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.profile_impact(&profileId)
         .await
@@ -706,9 +729,8 @@ pub struct CreatePromptInput {
 }
 
 #[tauri::command]
-pub async fn list_prompts(
-    config: State<'_, CoreConfig>,
-) -> Result<Vec<ManagedPromptRecordDto>, String> {
+pub async fn list_prompts(app: AppHandle) -> Result<Vec<ManagedPromptRecordDto>, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.list_prompts()
         .await
@@ -718,9 +740,10 @@ pub async fn list_prompts(
 
 #[tauri::command]
 pub async fn get_prompt(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     id: String,
 ) -> Result<Option<ManagedPromptRecordDto>, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.get_prompt(&id)
         .await
@@ -730,9 +753,10 @@ pub async fn get_prompt(
 
 #[tauri::command]
 pub async fn create_prompt(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     input: CreatePromptInput,
 ) -> Result<(String, StoredPromptDto), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     let profile_id = input.profile.map(AgentProfileId::from);
     svc.create_prompt(
@@ -748,10 +772,11 @@ pub async fn create_prompt(
 
 #[tauri::command]
 pub async fn save_prompt(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     id: String,
     prompt: StoredPromptDto,
 ) -> Result<(), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     let typed = StoredPrompt {
         display_name: prompt.display_name,
@@ -767,10 +792,11 @@ pub async fn save_prompt(
 
 #[tauri::command]
 pub async fn rename_prompt(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     id: String,
     newDisplayName: String,
 ) -> Result<(), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     svc.rename_prompt(&id, &newDisplayName)
         .await
@@ -778,19 +804,18 @@ pub async fn rename_prompt(
 }
 
 #[tauri::command]
-pub async fn delete_prompt(
-    config: State<'_, CoreConfig>,
-    id: String,
-) -> Result<(), MutationErrorDto> {
+pub async fn delete_prompt(app: AppHandle, id: String) -> Result<(), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     svc.delete_prompt(&id).await.map_err(MutationErrorDto::from)
 }
 
 #[tauri::command]
 pub async fn prompt_impact(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     promptId: String,
 ) -> Result<DependencyImpactReportDto, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.prompt_impact(&promptId)
         .await
@@ -803,9 +828,8 @@ pub async fn prompt_impact(
 // ============================================================================
 
 #[tauri::command]
-pub async fn list_credentials(
-    config: State<'_, CoreConfig>,
-) -> Result<Vec<CredentialSummaryDto>, String> {
+pub async fn list_credentials(app: AppHandle) -> Result<Vec<CredentialSummaryDto>, String> {
+    let config = shared_config(&app)?;
     let svc = service(&config);
     svc.list_credentials()
         .await
@@ -815,10 +839,11 @@ pub async fn list_credentials(
 
 #[tauri::command]
 pub async fn set_api_key(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     providerSlug: String,
     apiKey: String,
 ) -> Result<CredentialSummaryDto, MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     svc.set_api_key(&providerSlug, &apiKey)
         .await
@@ -828,9 +853,10 @@ pub async fn set_api_key(
 
 #[tauri::command]
 pub async fn delete_credential(
-    config: State<'_, CoreConfig>,
+    app: AppHandle,
     providerSlug: String,
 ) -> Result<(), MutationErrorDto> {
+    let config = shared_config_for_mutation(&app)?;
     let svc = service(&config);
     svc.delete_credential(&providerSlug)
         .await
@@ -853,7 +879,8 @@ pub async fn get_shared_config_error(
 // ============================================================================
 
 #[tauri::command]
-pub async fn seed_default_profiles(config: State<'_, CoreConfig>) -> Result<SeedReportDto, String> {
+pub async fn seed_default_profiles(app: AppHandle) -> Result<SeedReportDto, String> {
+    let config = shared_config(&app)?;
     let report = iron_core::profile::seed_default_profiles(
         &config.store,
         DefaultProfileSeedPolicy::FirstRunOnly,
@@ -884,9 +911,8 @@ pub async fn seed_default_profiles(config: State<'_, CoreConfig>) -> Result<Seed
 }
 
 #[tauri::command]
-pub async fn restore_default_profiles(
-    config: State<'_, CoreConfig>,
-) -> Result<SeedReportDto, String> {
+pub async fn restore_default_profiles(app: AppHandle) -> Result<SeedReportDto, String> {
+    let config = shared_config(&app)?;
     let report = iron_core::profile::seed_default_profiles(
         &config.store,
         DefaultProfileSeedPolicy::RestoreMissing,

--- a/src-tauri/src/commands/config_management.rs
+++ b/src-tauri/src/commands/config_management.rs
@@ -1,0 +1,1144 @@
+#![allow(non_snake_case)]
+use iron_core::management::{
+    ConfigManagementService, CredentialSummary, DependencyDirection, DependencyEntity,
+    DependencyImpactReport, DependencyLink, DependencyProximity, DiagnosticCategory,
+    ManagedProfileEntry, ManagedProfileRecord, ManagedPromptEntry, ManagedPromptRecord,
+    ManagedRecord, ManagementError, RecordDiagnostic,
+};
+use iron_core::profile::{
+    AgentApproval, AgentProfile, AgentProfileId, AgentProfileProvider, DefaultProfileSeedPolicy,
+    ProfileDeletePolicy, SkillFilter, ToolFilter,
+};
+use iron_core::stored_prompt::{IdentityState, StoredPrompt};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::core_config::CoreConfig;
+
+/// Managed state holding a shared-config initialization error.
+/// When `Some`, the frontend shows a blocking error and shared-config
+/// commands are unavailable.
+pub type SharedConfigError = std::sync::Mutex<Option<String>>;
+
+// ============================================================================
+// Serializable DTOs
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ProfileProviderDto {
+    RuntimeDefault,
+    Managed { providerSlug: String, model: String },
+}
+
+impl From<&AgentProfileProvider> for ProfileProviderDto {
+    fn from(p: &AgentProfileProvider) -> Self {
+        match p {
+            AgentProfileProvider::RuntimeDefault => ProfileProviderDto::RuntimeDefault,
+            AgentProfileProvider::Managed {
+                provider_slug,
+                model,
+            } => ProfileProviderDto::Managed {
+                providerSlug: provider_slug.as_str().to_string(),
+                model: model.clone(),
+            },
+        }
+    }
+}
+
+impl TryFrom<ProfileProviderDto> for AgentProfileProvider {
+    type Error = String;
+
+    fn try_from(dto: ProfileProviderDto) -> Result<Self, Self::Error> {
+        match dto {
+            ProfileProviderDto::RuntimeDefault => Ok(AgentProfileProvider::RuntimeDefault),
+            ProfileProviderDto::Managed {
+                providerSlug,
+                model,
+            } => {
+                let slug = providerSlug.trim();
+                let model = model.trim();
+                if slug.is_empty() {
+                    return Err("provider_slug must not be empty".to_string());
+                }
+                if model.is_empty() {
+                    return Err("model must not be empty".to_string());
+                }
+                Ok(AgentProfileProvider::Managed {
+                    provider_slug: iron_core::provider_credential::domain::ProviderSlug::new(slug),
+                    model: model.to_string(),
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentProfileDto {
+    pub name: String,
+    #[serde(flatten)]
+    pub provider: ProfileProviderDto,
+    pub tools: ToolFilterDto,
+    pub skills: SkillFilterDto,
+    pub approval: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity_prompt: Option<String>,
+}
+
+impl From<&AgentProfile> for AgentProfileDto {
+    fn from(p: &AgentProfile) -> Self {
+        Self {
+            name: p.name.clone(),
+            provider: ProfileProviderDto::from(&p.provider),
+            tools: ToolFilterDto::from(&p.tools),
+            skills: SkillFilterDto::from(&p.skills),
+            approval: match p.approval {
+                AgentApproval::PerTool => "perTool".to_string(),
+                AgentApproval::AutoApprove => "autoApprove".to_string(),
+            },
+            identity_prompt: p.identity_prompt.clone(),
+        }
+    }
+}
+
+impl TryFrom<AgentProfileDto> for AgentProfile {
+    type Error = String;
+
+    fn try_from(dto: AgentProfileDto) -> Result<Self, Self::Error> {
+        let approval = match dto.approval.as_str() {
+            "perTool" => AgentApproval::PerTool,
+            "autoApprove" => AgentApproval::AutoApprove,
+            other => {
+                return Err(format!("Unsupported approval policy: {other}"));
+            }
+        };
+        Ok(Self {
+            name: dto.name,
+            provider: dto.provider.try_into()?,
+            tools: dto.tools.into(),
+            skills: dto.skills.into(),
+            approval,
+            identity_prompt: dto.identity_prompt,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ToolFilterDto {
+    Inherit,
+    Allow { names: Vec<String> },
+    Deny { names: Vec<String> },
+}
+
+impl From<&ToolFilter> for ToolFilterDto {
+    fn from(f: &ToolFilter) -> Self {
+        match f {
+            ToolFilter::Inherit => ToolFilterDto::Inherit,
+            ToolFilter::Allow(names) => ToolFilterDto::Allow {
+                names: names.clone(),
+            },
+            ToolFilter::Deny(names) => ToolFilterDto::Deny {
+                names: names.clone(),
+            },
+        }
+    }
+}
+
+impl From<ToolFilterDto> for ToolFilter {
+    fn from(dto: ToolFilterDto) -> Self {
+        match dto {
+            ToolFilterDto::Inherit => ToolFilter::Inherit,
+            ToolFilterDto::Allow { names } => ToolFilter::Allow(names),
+            ToolFilterDto::Deny { names } => ToolFilter::Deny(names),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum SkillFilterDto {
+    None,
+    Allow { names: Vec<String> },
+    Inherit,
+}
+
+impl From<&SkillFilter> for SkillFilterDto {
+    fn from(f: &SkillFilter) -> Self {
+        match f {
+            SkillFilter::None => SkillFilterDto::None,
+            SkillFilter::Allow(names) => SkillFilterDto::Allow {
+                names: names.clone(),
+            },
+            SkillFilter::Inherit => SkillFilterDto::Inherit,
+        }
+    }
+}
+
+impl From<SkillFilterDto> for SkillFilter {
+    fn from(dto: SkillFilterDto) -> Self {
+        match dto {
+            SkillFilterDto::None => SkillFilter::None,
+            SkillFilterDto::Allow { names } => SkillFilter::Allow(names),
+            SkillFilterDto::Inherit => SkillFilter::Inherit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedProfileEntryDto {
+    pub id: String,
+    pub profile: AgentProfileDto,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum ManagedProfileRecordDto {
+    Ready {
+        entry: ManagedProfileEntryDto,
+    },
+    NeedsAttention {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decoded: Option<AgentProfileDto>,
+        diagnostics: Vec<RecordDiagnosticDto>,
+    },
+}
+
+impl From<ManagedProfileRecord> for ManagedProfileRecordDto {
+    fn from(record: ManagedProfileRecord) -> Self {
+        match record {
+            ManagedRecord::Ready(ManagedProfileEntry {
+                id,
+                profile,
+                created_at,
+                updated_at,
+            }) => ManagedProfileRecordDto::Ready {
+                entry: ManagedProfileEntryDto {
+                    id: id.as_str().to_string(),
+                    profile: AgentProfileDto::from(&profile),
+                    created_at: created_at.to_rfc3339(),
+                    updated_at: updated_at.to_rfc3339(),
+                },
+            },
+            ManagedRecord::NeedsAttention {
+                id,
+                decoded,
+                diagnostics,
+            } => ManagedProfileRecordDto::NeedsAttention {
+                id,
+                decoded: decoded.as_ref().map(|e| AgentProfileDto::from(&e.profile)),
+                diagnostics: diagnostics.into_iter().map(Into::into).collect(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredPromptDto {
+    pub display_name: String,
+    pub normalized_name: String,
+    pub instructions: String,
+    pub skills: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+}
+
+impl From<&StoredPrompt> for StoredPromptDto {
+    fn from(p: &StoredPrompt) -> Self {
+        Self {
+            display_name: p.display_name.clone(),
+            normalized_name: p.normalized_name.clone(),
+            instructions: p.instructions.clone(),
+            skills: p.skills.clone(),
+            profile: p.profile.as_ref().map(|id| id.as_str().to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedPromptEntryDto {
+    pub id: String,
+    pub prompt: StoredPromptDto,
+    pub identity_state: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum ManagedPromptRecordDto {
+    Ready {
+        entry: ManagedPromptEntryDto,
+    },
+    NeedsAttention {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decoded: Option<StoredPromptDto>,
+        diagnostics: Vec<RecordDiagnosticDto>,
+    },
+}
+
+impl From<ManagedPromptRecord> for ManagedPromptRecordDto {
+    fn from(record: ManagedPromptRecord) -> Self {
+        match record {
+            ManagedRecord::Ready((
+                id,
+                ManagedPromptEntry {
+                    prompt,
+                    identity_state,
+                    created_at,
+                    updated_at,
+                },
+            )) => ManagedPromptRecordDto::Ready {
+                entry: ManagedPromptEntryDto {
+                    id,
+                    prompt: StoredPromptDto::from(&prompt),
+                    identity_state: match identity_state {
+                        IdentityState::Ready => "ready".to_string(),
+                        IdentityState::NeedsRename => "needsRename".to_string(),
+                    },
+                    created_at: created_at.to_rfc3339(),
+                    updated_at: updated_at.to_rfc3339(),
+                },
+            },
+            ManagedRecord::NeedsAttention {
+                id,
+                decoded,
+                diagnostics,
+            } => ManagedPromptRecordDto::NeedsAttention {
+                id,
+                decoded: decoded
+                    .as_ref()
+                    .map(|(_, e)| StoredPromptDto::from(&e.prompt)),
+                diagnostics: diagnostics.into_iter().map(Into::into).collect(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordDiagnosticDto {
+    pub category: String,
+    pub message: String,
+}
+
+impl From<RecordDiagnostic> for RecordDiagnosticDto {
+    fn from(d: RecordDiagnostic) -> Self {
+        Self {
+            category: match d.category {
+                DiagnosticCategory::UnsupportedSchemaVersion => "unsupportedSchemaVersion",
+                DiagnosticCategory::InvalidPayload => "invalidPayload",
+                DiagnosticCategory::MissingRecord => "missingRecord",
+                DiagnosticCategory::UnavailableProfile => "unavailableProfile",
+                DiagnosticCategory::UnavailableSkill => "unavailableSkill",
+                DiagnosticCategory::NeedsRename => "needsRename",
+                DiagnosticCategory::ReadOnlyRejected => "readOnlyRejected",
+                DiagnosticCategory::UnknownIdentityState => "unknownIdentityState",
+            }
+            .to_string(),
+            message: d.message,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialSummaryDto {
+    pub provider_slug: String,
+    pub credential_mode: String,
+    pub auth_status: String,
+    pub expires_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<CredentialSummary> for CredentialSummaryDto {
+    fn from(c: CredentialSummary) -> Self {
+        let (auth_status, expires_at) = match &c.auth_status {
+            iron_core::provider_credential::domain::ProviderAuthStatus::ConfiguredApiKey => {
+                ("configuredApiKey".to_string(), None)
+            }
+            iron_core::provider_credential::domain::ProviderAuthStatus::ConnectedOAuth {
+                expires_at,
+            } => {
+                let ts = expires_at.map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+                ("connectedOAuth".to_string(), ts)
+            }
+            iron_core::provider_credential::domain::ProviderAuthStatus::Refreshing => {
+                ("refreshing".to_string(), None)
+            }
+            iron_core::provider_credential::domain::ProviderAuthStatus::Expired => {
+                ("expired".to_string(), None)
+            }
+            iron_core::provider_credential::domain::ProviderAuthStatus::RefreshFailed {
+                reason,
+            } => (format!("refreshFailed:{}", reason), None),
+            iron_core::provider_credential::domain::ProviderAuthStatus::Revoked => {
+                ("revoked".to_string(), None)
+            }
+            iron_core::provider_credential::domain::ProviderAuthStatus::NotConfigured => {
+                ("notConfigured".to_string(), None)
+            }
+            iron_core::provider_credential::domain::ProviderAuthStatus::UnsupportedCredential => {
+                ("unsupported".to_string(), None)
+            }
+        };
+        Self {
+            provider_slug: c.provider_slug,
+            credential_mode: format!("{:?}", c.credential_mode).to_lowercase(),
+            auth_status,
+            expires_at,
+            created_at: c.created_at.to_rfc3339(),
+            updated_at: c.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum DependencyEntityDto {
+    ProviderCredential { slug: String },
+    Profile { id: String },
+    Prompt { id: String },
+    AutomationTask { id: String },
+    ScheduledTask { id: String },
+}
+
+impl From<DependencyEntity> for DependencyEntityDto {
+    fn from(entity: DependencyEntity) -> Self {
+        match entity {
+            DependencyEntity::ProviderCredential { slug } => Self::ProviderCredential { slug },
+            DependencyEntity::Profile { id } => Self::Profile { id },
+            DependencyEntity::Prompt { id } => Self::Prompt { id },
+            DependencyEntity::AutomationTask { id } => Self::AutomationTask { id },
+            DependencyEntity::ScheduledTask { id } => Self::ScheduledTask { id },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyLinkDto {
+    pub entity: DependencyEntityDto,
+    pub direction: String,
+    pub proximity: String,
+    pub path: Vec<DependencyEntityDto>,
+}
+
+impl From<DependencyLink> for DependencyLinkDto {
+    fn from(link: DependencyLink) -> Self {
+        Self {
+            entity: link.entity.into(),
+            direction: match link.direction {
+                DependencyDirection::Depends => "depends",
+                DependencyDirection::Dependent => "dependent",
+            }
+            .to_string(),
+            proximity: match link.proximity {
+                DependencyProximity::Direct => "direct",
+                DependencyProximity::Transitive => "transitive",
+            }
+            .to_string(),
+            path: link.path.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyImpactReportDto {
+    pub target: DependencyEntityDto,
+    pub links: Vec<DependencyLinkDto>,
+    pub diagnostics: Vec<String>,
+}
+
+impl From<DependencyImpactReport> for DependencyImpactReportDto {
+    fn from(report: DependencyImpactReport) -> Self {
+        Self {
+            target: report.target.into(),
+            links: report.links.into_iter().map(Into::into).collect(),
+            diagnostics: report.diagnostics,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedReportDto {
+    pub policy: String,
+    pub marker_was_present: bool,
+    pub marker_written: bool,
+    pub created: Vec<String>,
+    pub skipped_existing: Vec<String>,
+    pub diagnostics: Vec<String>,
+}
+
+// ============================================================================
+// Error conversion
+// ============================================================================
+
+/// Typed mutation error that the frontend can map to specific form fields.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MutationErrorDto {
+    pub kind: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub referrers: Vec<String>,
+}
+
+impl From<ManagementError> for MutationErrorDto {
+    fn from(e: ManagementError) -> Self {
+        match e {
+            ManagementError::Validation(msg) => {
+                let field = infer_error_field(&msg);
+                MutationErrorDto {
+                    kind: "validation".to_string(),
+                    message: msg,
+                    field,
+                    referrers: Vec::new(),
+                }
+            }
+            ManagementError::Reference(msg) => {
+                let field = infer_error_field(&msg);
+                MutationErrorDto {
+                    kind: "reference".to_string(),
+                    message: msg,
+                    field,
+                    referrers: Vec::new(),
+                }
+            }
+            ManagementError::Conflict { target, referrers } => MutationErrorDto {
+                kind: "conflict".to_string(),
+                message: format!("'{target}' is referenced by: {}", referrers.join(", ")),
+                field: None,
+                referrers,
+            },
+            ManagementError::Storage(inner) => MutationErrorDto {
+                kind: "storage".to_string(),
+                message: format!("Storage error: {inner}"),
+                field: None,
+                referrers: Vec::new(),
+            },
+            ManagementError::IntegrityUnknown { details } => MutationErrorDto {
+                kind: "integrityUnknown".to_string(),
+                message: format!("Cannot verify referential integrity: {details}"),
+                field: None,
+                referrers: Vec::new(),
+            },
+            ManagementError::MinimumValidProfiles { minimum, remaining } => MutationErrorDto {
+                kind: "minimumValidProfiles".to_string(),
+                message: format!(
+                    "Cannot delete this profile: at least {minimum} valid profile must remain ({remaining} would remain)."
+                ),
+                field: None,
+                referrers: Vec::new(),
+            },
+            ManagementError::SchedulerUnavailable => MutationErrorDto {
+                kind: "schedulerUnavailable".to_string(),
+                message: "Scheduler is not attached".to_string(),
+                field: None,
+                referrers: Vec::new(),
+            },
+            ManagementError::Scheduler(msg) => MutationErrorDto {
+                kind: "scheduler".to_string(),
+                message: msg,
+                field: None,
+                referrers: Vec::new(),
+            },
+            ManagementError::Partial {
+                target,
+                durable_succeeded,
+                error,
+            } => MutationErrorDto {
+                kind: "partial".to_string(),
+                message: format!(
+                    "Partial operation for '{target}': durable_succeeded={durable_succeeded}, error={error}"
+                ),
+                field: None,
+                referrers: Vec::new(),
+            },
+        }
+    }
+}
+
+/// Infer which form field a validation/reference error relates to.
+fn infer_error_field(msg: &str) -> Option<String> {
+    let lower = msg.to_lowercase();
+    if lower.contains("normalized")
+        || lower.contains("handle")
+        || lower.contains("collision")
+        || lower.contains("display name")
+        || lower.contains("name ")
+        || lower.contains("name.")
+    {
+        Some("displayName".to_string())
+    } else if lower.contains("provider") {
+        Some("providerSlug".to_string())
+    } else if lower.contains("model") {
+        Some("model".to_string())
+    } else {
+        None
+    }
+}
+
+fn management_error_to_string(e: ManagementError) -> String {
+    match e {
+        ManagementError::Storage(inner) => format!("Storage error: {inner}"),
+        ManagementError::Validation(msg) => msg,
+        ManagementError::Reference(msg) => msg,
+        ManagementError::Conflict { target, referrers } => {
+            format!("'{target}' is referenced by: {}", referrers.join(", "))
+        }
+        ManagementError::IntegrityUnknown { details } => {
+            format!("Cannot verify referential integrity: {details}")
+        }
+        ManagementError::MinimumValidProfiles { minimum, remaining } => format!(
+            "Cannot delete this profile: at least {minimum} valid profile must remain ({remaining} would remain)."
+        ),
+        ManagementError::SchedulerUnavailable => "Scheduler is not attached".to_string(),
+        ManagementError::Scheduler(msg) => msg,
+        ManagementError::Partial {
+            target,
+            durable_succeeded,
+            error,
+        } => {
+            format!("Partial operation for '{target}': durable_succeeded={durable_succeeded}, error={error}")
+        }
+    }
+}
+
+fn service(config: &CoreConfig) -> ConfigManagementService {
+    ConfigManagementService::new((*config.store).clone())
+}
+
+// ============================================================================
+// Profile commands
+// ============================================================================
+
+#[tauri::command]
+pub async fn list_profiles(
+    config: State<'_, CoreConfig>,
+) -> Result<Vec<ManagedProfileRecordDto>, String> {
+    let svc = service(&config);
+    svc.list_profiles()
+        .await
+        .map_err(management_error_to_string)
+        .map(|records| records.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command]
+pub async fn get_profile(
+    config: State<'_, CoreConfig>,
+    id: String,
+) -> Result<Option<ManagedProfileRecordDto>, String> {
+    let svc = service(&config);
+    svc.get_profile(&id)
+        .await
+        .map_err(management_error_to_string)
+        .map(|opt| opt.map(Into::into))
+}
+
+#[tauri::command]
+pub async fn save_profile(
+    config: State<'_, CoreConfig>,
+    id: String,
+    profile: AgentProfileDto,
+) -> Result<(), MutationErrorDto> {
+    let svc = service(&config);
+    let typed: AgentProfile = profile.try_into().map_err(|e: String| MutationErrorDto {
+        kind: "validation".to_string(),
+        message: e,
+        field: None,
+        referrers: Vec::new(),
+    })?;
+    svc.save_profile(&id, &typed)
+        .await
+        .map_err(MutationErrorDto::from)
+}
+
+#[tauri::command]
+pub async fn delete_profile(
+    config: State<'_, CoreConfig>,
+    id: String,
+) -> Result<(), MutationErrorDto> {
+    let svc = service(&config);
+
+    svc.delete_profile_with_policy(&id, ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .map_err(MutationErrorDto::from)
+}
+
+#[tauri::command]
+pub async fn profile_impact(
+    config: State<'_, CoreConfig>,
+    profileId: String,
+) -> Result<DependencyImpactReportDto, String> {
+    let svc = service(&config);
+    svc.profile_impact(&profileId)
+        .await
+        .map_err(management_error_to_string)
+        .map(Into::into)
+}
+
+// ============================================================================
+// Prompt commands
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatePromptInput {
+    pub display_name: String,
+    pub instructions: String,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    pub profile: Option<String>,
+}
+
+#[tauri::command]
+pub async fn list_prompts(
+    config: State<'_, CoreConfig>,
+) -> Result<Vec<ManagedPromptRecordDto>, String> {
+    let svc = service(&config);
+    svc.list_prompts()
+        .await
+        .map_err(management_error_to_string)
+        .map(|records| records.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command]
+pub async fn get_prompt(
+    config: State<'_, CoreConfig>,
+    id: String,
+) -> Result<Option<ManagedPromptRecordDto>, String> {
+    let svc = service(&config);
+    svc.get_prompt(&id)
+        .await
+        .map_err(management_error_to_string)
+        .map(|opt| opt.map(Into::into))
+}
+
+#[tauri::command]
+pub async fn create_prompt(
+    config: State<'_, CoreConfig>,
+    input: CreatePromptInput,
+) -> Result<(String, StoredPromptDto), MutationErrorDto> {
+    let svc = service(&config);
+    let profile_id = input.profile.map(AgentProfileId::from);
+    svc.create_prompt(
+        &input.display_name,
+        &input.instructions,
+        input.skills,
+        profile_id,
+    )
+    .await
+    .map_err(MutationErrorDto::from)
+    .map(|(id, prompt)| (id, StoredPromptDto::from(&prompt)))
+}
+
+#[tauri::command]
+pub async fn save_prompt(
+    config: State<'_, CoreConfig>,
+    id: String,
+    prompt: StoredPromptDto,
+) -> Result<(), MutationErrorDto> {
+    let svc = service(&config);
+    let typed = StoredPrompt {
+        display_name: prompt.display_name,
+        normalized_name: prompt.normalized_name,
+        instructions: prompt.instructions,
+        skills: prompt.skills,
+        profile: prompt.profile.map(AgentProfileId::from),
+    };
+    svc.save_prompt(&id, &typed)
+        .await
+        .map_err(MutationErrorDto::from)
+}
+
+#[tauri::command]
+pub async fn rename_prompt(
+    config: State<'_, CoreConfig>,
+    id: String,
+    newDisplayName: String,
+) -> Result<(), MutationErrorDto> {
+    let svc = service(&config);
+    svc.rename_prompt(&id, &newDisplayName)
+        .await
+        .map_err(MutationErrorDto::from)
+}
+
+#[tauri::command]
+pub async fn delete_prompt(
+    config: State<'_, CoreConfig>,
+    id: String,
+) -> Result<(), MutationErrorDto> {
+    let svc = service(&config);
+    svc.delete_prompt(&id).await.map_err(MutationErrorDto::from)
+}
+
+#[tauri::command]
+pub async fn prompt_impact(
+    config: State<'_, CoreConfig>,
+    promptId: String,
+) -> Result<DependencyImpactReportDto, String> {
+    let svc = service(&config);
+    svc.prompt_impact(&promptId)
+        .await
+        .map_err(management_error_to_string)
+        .map(Into::into)
+}
+
+// ============================================================================
+// Credential commands
+// ============================================================================
+
+#[tauri::command]
+pub async fn list_credentials(
+    config: State<'_, CoreConfig>,
+) -> Result<Vec<CredentialSummaryDto>, String> {
+    let svc = service(&config);
+    svc.list_credentials()
+        .await
+        .map_err(management_error_to_string)
+        .map(|creds| creds.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command]
+pub async fn set_api_key(
+    config: State<'_, CoreConfig>,
+    providerSlug: String,
+    apiKey: String,
+) -> Result<CredentialSummaryDto, MutationErrorDto> {
+    let svc = service(&config);
+    svc.set_api_key(&providerSlug, &apiKey)
+        .await
+        .map_err(MutationErrorDto::from)
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn delete_credential(
+    config: State<'_, CoreConfig>,
+    providerSlug: String,
+) -> Result<(), MutationErrorDto> {
+    let svc = service(&config);
+    svc.delete_credential(&providerSlug)
+        .await
+        .map_err(MutationErrorDto::from)
+}
+
+// ============================================================================
+// Shared-config initialization status
+// ============================================================================
+
+#[tauri::command]
+pub async fn get_shared_config_error(
+    error: State<'_, SharedConfigError>,
+) -> Result<Option<String>, String> {
+    Ok(error.lock().map_err(|e| e.to_string())?.clone())
+}
+
+// ============================================================================
+// Seed / recovery commands
+// ============================================================================
+
+#[tauri::command]
+pub async fn seed_default_profiles(config: State<'_, CoreConfig>) -> Result<SeedReportDto, String> {
+    let report = iron_core::profile::seed_default_profiles(
+        &config.store,
+        DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .map_err(|e| format!("Failed to seed default profiles: {e}"))?;
+
+    Ok(SeedReportDto {
+        policy: "firstRunOnly".to_string(),
+        marker_was_present: report.marker_was_present,
+        marker_written: report.marker_written,
+        created: report
+            .created
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect(),
+        skipped_existing: report
+            .skipped_existing
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect(),
+        diagnostics: report
+            .diagnostics
+            .iter()
+            .map(|d| format!("{:?}", d))
+            .collect(),
+    })
+}
+
+#[tauri::command]
+pub async fn restore_default_profiles(
+    config: State<'_, CoreConfig>,
+) -> Result<SeedReportDto, String> {
+    let report = iron_core::profile::seed_default_profiles(
+        &config.store,
+        DefaultProfileSeedPolicy::RestoreMissing,
+    )
+    .await
+    .map_err(|e| format!("Failed to restore default profiles: {e}"))?;
+
+    Ok(SeedReportDto {
+        policy: "restoreMissing".to_string(),
+        marker_was_present: report.marker_was_present,
+        marker_written: report.marker_written,
+        created: report
+            .created
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect(),
+        skipped_existing: report
+            .skipped_existing
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect(),
+        diagnostics: report
+            .diagnostics
+            .iter()
+            .map(|d| format!("{:?}", d))
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_dto_roundtrip_runtime_default() {
+        let profile = AgentProfile::with_name("Test");
+        let dto = AgentProfileDto::from(&profile);
+        assert_eq!(dto.name, "Test");
+        assert!(matches!(dto.provider, ProfileProviderDto::RuntimeDefault));
+        assert_eq!(dto.approval, "perTool");
+    }
+
+    #[test]
+    fn profile_dto_managed_provider() {
+        let profile = AgentProfile {
+            name: "Managed".to_string(),
+            provider: AgentProfileProvider::Managed {
+                provider_slug: iron_core::provider_credential::domain::ProviderSlug::new("openai"),
+                model: "gpt-4o".to_string(),
+            },
+            tools: ToolFilter::Allow(vec!["search".to_string()]),
+            skills: SkillFilter::Inherit,
+            approval: AgentApproval::AutoApprove,
+            identity_prompt: Some("You are helpful.".to_string()),
+        };
+        let dto = AgentProfileDto::from(&profile);
+        match &dto.provider {
+            ProfileProviderDto::Managed {
+                providerSlug,
+                model,
+            } => {
+                assert_eq!(providerSlug, "openai");
+                assert_eq!(model, "gpt-4o");
+            }
+            _ => panic!("expected Managed provider"),
+        }
+        assert_eq!(dto.approval, "autoApprove");
+    }
+
+    #[test]
+    fn tool_filter_dto_roundtrip() {
+        let cases = vec![
+            (ToolFilter::Inherit, ToolFilterDto::Inherit),
+            (
+                ToolFilter::Allow(vec!["a".into(), "b".into()]),
+                ToolFilterDto::Allow {
+                    names: vec!["a".into(), "b".into()],
+                },
+            ),
+            (
+                ToolFilter::Deny(vec!["c".into()]),
+                ToolFilterDto::Deny {
+                    names: vec!["c".into()],
+                },
+            ),
+        ];
+        for (original, dto) in cases {
+            let converted: ToolFilter = dto.into();
+            assert_eq!(converted, original);
+        }
+    }
+
+    #[test]
+    fn credential_summary_dto_never_exposes_secret() {
+        let summary = CredentialSummary {
+            provider_slug: "openai".to_string(),
+            credential_mode: iron_core::provider_credential::domain::CredentialMode::ApiKey,
+            auth_status:
+                iron_core::provider_credential::domain::ProviderAuthStatus::ConfiguredApiKey,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let dto = CredentialSummaryDto::from(summary);
+        assert_eq!(dto.auth_status, "configuredApiKey");
+        let json = serde_json::to_string(&dto).unwrap();
+        assert!(!json.contains("sk-"));
+    }
+
+    #[test]
+    fn dependency_impact_dto_preserves_typed_links_and_paths() {
+        let target = DependencyEntity::Profile {
+            id: "profile-1".to_string(),
+        };
+        let prompt = DependencyEntity::Prompt {
+            id: "prompt-1".to_string(),
+        };
+        let task = DependencyEntity::AutomationTask {
+            id: "task-1".to_string(),
+        };
+        let report = DependencyImpactReport {
+            target: target.clone(),
+            links: vec![
+                DependencyLink {
+                    entity: prompt.clone(),
+                    direction: DependencyDirection::Dependent,
+                    proximity: DependencyProximity::Direct,
+                    path: vec![target.clone(), prompt.clone()],
+                },
+                DependencyLink {
+                    entity: task.clone(),
+                    direction: DependencyDirection::Dependent,
+                    proximity: DependencyProximity::Transitive,
+                    path: vec![target, prompt, task],
+                },
+            ],
+            diagnostics: Vec::new(),
+        };
+
+        let json = serde_json::to_value(DependencyImpactReportDto::from(report)).unwrap();
+        assert_eq!(json["target"]["kind"], "profile");
+        assert_eq!(json["links"][0]["entity"]["kind"], "prompt");
+        assert_eq!(json["links"][0]["direction"], "dependent");
+        assert_eq!(json["links"][1]["entity"]["kind"], "automationTask");
+        assert_eq!(json["links"][1]["proximity"], "transitive");
+        assert_eq!(json["links"][1]["path"][1]["kind"], "prompt");
+    }
+
+    #[test]
+    fn minimum_valid_profiles_error_maps_to_typed_mutation_error() {
+        let dto = MutationErrorDto::from(ManagementError::MinimumValidProfiles {
+            minimum: 1,
+            remaining: 0,
+        });
+
+        assert_eq!(dto.kind, "minimumValidProfiles");
+        assert!(dto.message.contains("at least 1 valid profile"));
+    }
+
+    #[tokio::test]
+    async fn list_profiles_round_trip_with_seed() {
+        let store = iron_core::config::ConfigStore::open_in_memory()
+            .await
+            .unwrap();
+        iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::RestoreMissing,
+        )
+        .await
+        .unwrap();
+        let svc = ConfigManagementService::new(store);
+        let records = svc.list_profiles().await.unwrap();
+        assert_eq!(records.len(), 3);
+        assert!(records.iter().all(|r| matches!(r, ManagedRecord::Ready(_))));
+    }
+
+    #[tokio::test]
+    async fn core_service_allows_last_profile_deletion() {
+        // The unrestricted core API remains backward compatible.
+        let store = iron_core::config::ConfigStore::open_in_memory()
+            .await
+            .unwrap();
+        iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::RestoreMissing,
+        )
+        .await
+        .unwrap();
+        let svc = ConfigManagementService::new(store);
+        svc.delete_profile("explore").await.unwrap();
+        svc.delete_profile("plan").await.unwrap();
+        svc.delete_profile("apply").await.unwrap();
+        assert!(svc.list_profiles().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn core_policy_rejects_deleting_last_valid_profile() {
+        let store = iron_core::config::ConfigStore::open_in_memory()
+            .await
+            .unwrap();
+        iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::RestoreMissing,
+        )
+        .await
+        .unwrap();
+        let svc = ConfigManagementService::new(store);
+        svc.delete_profile("explore").await.unwrap();
+        svc.delete_profile("plan").await.unwrap();
+
+        let result = svc
+            .delete_profile_with_policy("apply", ProfileDeletePolicy::RequireMinimumValid(1))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ManagementError::MinimumValidProfiles {
+                minimum: 1,
+                remaining: 0
+            })
+        ));
+        assert!(svc.get_profile("apply").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn credential_set_and_delete_redacted() {
+        let store = iron_core::config::ConfigStore::open_in_memory()
+            .await
+            .unwrap();
+        let svc = ConfigManagementService::new(store);
+        svc.set_api_key("openai", "sk-test-secret").await.unwrap();
+        let creds = svc.list_credentials().await.unwrap();
+        assert_eq!(creds.len(), 1);
+        let dto = CredentialSummaryDto::from(creds[0].clone());
+        let json = serde_json::to_string(&dto).unwrap();
+        assert!(!json.contains("sk-test-secret"));
+        svc.delete_credential("openai").await.unwrap();
+        assert!(svc.list_credentials().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_and_delete_prompt() {
+        let store = iron_core::config::ConfigStore::open_in_memory()
+            .await
+            .unwrap();
+        let svc = ConfigManagementService::new(store);
+        let (id, prompt) = svc
+            .create_prompt("My Task", "Do the thing", vec![], None)
+            .await
+            .unwrap();
+        assert_eq!(prompt.display_name, "My Task");
+        assert!(!id.is_empty());
+        svc.delete_prompt(&id).await.unwrap();
+        assert!(svc.list_prompts().await.unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod chat;
+pub mod config_management;
 pub mod models;
 pub mod oauth;
 pub mod settings;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -2,7 +2,6 @@ use iron_core::config::{
     CustomModelInput, CustomModelRecord, DefaultModelInput, McpServerConfigInput,
     McpServerConfigRecord, ProviderConfigInput, SkillSettingsInput, SkillSettingsRecord,
 };
-use iron_core::provider_credential::domain::StoredCredential;
 use rusqlite::Connection;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -10,7 +9,6 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Manager, State};
 
 use crate::core_config::CoreConfig;
-
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SettingRow {
@@ -112,11 +110,12 @@ async fn load_core_owned_settings(
         .list_provider_configs()
         .await
         .map_err(|e| format!("Failed to load provider configs: {e}"))?;
-    let credentials = store
-        .list_credential_slugs()
-        .await
-        .map_err(|e| format!("Failed to list credential slugs: {e}"))?;
 
+    // Do NOT load saved API keys from the credential store into the frontend
+    // response. Credential status is queried separately through typed
+    // config-management commands (list_credentials) that return only
+    // secret-safe metadata. The api_key field remains None so persisted
+    // secret values never enter long-lived frontend state.
     let providers: Vec<ProviderConfigJson> = provider_configs
         .into_iter()
         .map(|p| ProviderConfigJson {
@@ -128,22 +127,9 @@ async fn load_core_owned_settings(
         })
         .collect();
 
-    // Fill in API keys from the credential store without exposing them in logs.
-    let mut providers_with_keys = providers;
-    for provider in &mut providers_with_keys {
-        if credentials.contains(&provider.id) {
-            if let Ok(Some(bytes)) = store.get_credential(&provider.id).await {
-                provider.api_key = match serde_json::from_slice::<StoredCredential>(&bytes) {
-                    Ok(StoredCredential::ApiKey(key)) => Some(key),
-                    Ok(StoredCredential::OAuthBearer(_)) => None,
-                    Err(_) => None,
-                };
-            }
-        }
-    }
     rows.push(SettingRow {
         key: "providers".to_string(),
-        value: serde_json::to_string(&providers_with_keys)
+        value: serde_json::to_string(&providers)
             .map_err(|e| format!("Failed to serialize providers: {e}"))?,
     });
 
@@ -299,48 +285,9 @@ async fn save_providers(store: &iron_core::config::ConfigStore, value: &str) -> 
             .await
             .map_err(|e| format!("Failed to save provider config '{}': {}", provider.id, e))?;
 
-        let existing_bytes = store.get_credential(&provider.id).await.map_err(|e| {
-            format!(
-                "Failed to read existing credential for '{}': {}",
-                provider.id, e
-            )
-        })?;
-        let is_oauth = matches!(
-            existing_bytes
-                .as_deref()
-                .and_then(|b| serde_json::from_slice::<StoredCredential>(b).ok()),
-            Some(StoredCredential::OAuthBearer(_))
-        );
-
-        match provider.api_key.as_deref().map(str::trim) {
-            None => {
-                // No key was sent; preserve the existing credential (e.g. OAuth).
-            }
-            Some("") if is_oauth => {
-                // Frontend sends an empty apiKey for OAuth-backed providers by default.
-                // Preserve the OAuth credential instead of deleting it.
-            }
-            Some("") => {
-                store.remove_credential(&provider.id).await.map_err(|e| {
-                    format!("Failed to remove API key for '{}': {}", provider.id, e)
-                })?;
-            }
-            Some(key) => {
-                let credential = StoredCredential::ApiKey(key.to_string());
-                let payload = serde_json::to_vec(&credential)
-                    .map_err(|e| format!("Failed to serialize API key: {e}"))?;
-                store
-                    .set_credential(&provider.id, "api_key", &payload)
-                    .await
-                    .map_err(|e| {
-                        if matches!(e, iron_core::config::ConfigError::KeyUnavailable(_)) {
-                            "Credential encryption is unavailable. Set AGENTIRON_CONFIG_ENCRYPTION_KEY or ensure your OS keyring is accessible.".to_string()
-                        } else {
-                            format!("Failed to save API key: {e}")
-                        }
-                    })?;
-            }
-        }
+        // Credentials are managed through typed config-management commands
+        // (set_api_key, delete_credential). The legacy whole-provider save
+        // path must not touch stored credentials.
     }
 
     Ok(())

--- a/src-tauri/src/core_config.rs
+++ b/src-tauri/src/core_config.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use base64::Engine;
 use iron_core::config::{
     crypto::{DynCredentialCipher, XChaCha20Poly1305Cipher},
-    ConfigError, ConfigStore, CustomModelInput, DefaultModelInput, McpServerConfigInput,
-    OpenOptions, ProviderConfigInput, SkillSettingsInput,
+    BootstrapMetadataInput, ConfigError, ConfigStore, CustomModelInput, DefaultModelInput,
+    McpServerConfigInput, OpenOptions, ProviderConfigInput, SkillSettingsInput,
 };
 use iron_core::provider_credential::{
     domain::{OAuthTokenSet, ProviderSlug, StoredCredential},
@@ -15,6 +15,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
 
+const MIGRATION_DOMAIN: &str = "agentiron";
+const MIGRATION_KEY: &str = "migration.v1";
 const MIGRATION_PROFILE_ID: &str = "agentiron.migration.v1";
 const MIGRATION_VERSION: i64 = 1;
 
@@ -186,28 +188,57 @@ pub async fn migrate_legacy_settings(
     store: &ConfigStore,
     legacy_conn: &Connection,
 ) -> Result<(), String> {
-    if is_migration_complete(store).await? {
+    // Check whether the durable metadata marker already exists.
+    let has_metadata = has_metadata_marker(store).await?;
+
+    if has_metadata {
+        // Metadata already exists, but the legacy fake-profile marker may
+        // not have been cleaned up (e.g. a crash between the metadata write
+        // and marker deletion). Attempt cleanup now; failure is non-fatal
+        // and will be retried on the next startup.
+        let _ = store.delete_profile(MIGRATION_PROFILE_ID).await;
         return Ok(());
     }
 
-    // Migrate in an order that satisfies cross-record validation:
-    // providers -> custom models -> default model -> MCP servers -> skills -> credentials.
-    migrate_providers(store, legacy_conn).await?;
-    migrate_custom_models(store, legacy_conn).await?;
-    migrate_default_model(store, legacy_conn).await?;
-    migrate_mcp_servers(store, legacy_conn).await?;
-    migrate_skill_settings(store, legacy_conn).await?;
-    migrate_credentials(store, legacy_conn).await?;
+    // Check whether the legacy profile marker says migration completed.
+    let already_completed = is_legacy_marker_complete(store).await?;
 
-    // Delete migrated core-owned keys from the legacy settings table.
-    delete_legacy_core_keys(legacy_conn)?;
+    if !already_completed {
+        // Migrate in an order that satisfies cross-record validation:
+        // providers -> custom models -> default model -> MCP servers -> skills -> credentials.
+        migrate_providers(store, legacy_conn).await?;
+        migrate_custom_models(store, legacy_conn).await?;
+        migrate_default_model(store, legacy_conn).await?;
+        migrate_mcp_servers(store, legacy_conn).await?;
+        migrate_skill_settings(store, legacy_conn).await?;
+        migrate_credentials(store, legacy_conn).await?;
 
+        // Delete migrated core-owned keys from the legacy settings table.
+        delete_legacy_core_keys(legacy_conn)?;
+    }
+
+    // Always record completion in the new metadata format and remove the
+    // legacy fake-profile marker. This runs whether migration just happened
+    // or was already done under the old marker scheme.
     record_migration_complete(store).await?;
 
     Ok(())
 }
 
-async fn is_migration_complete(store: &ConfigStore) -> Result<bool, String> {
+/// Check whether the durable bootstrap metadata marker exists.
+async fn has_metadata_marker(store: &ConfigStore) -> Result<bool, String> {
+    match store
+        .get_bootstrap_metadata(MIGRATION_DOMAIN, MIGRATION_KEY)
+        .await
+    {
+        Ok(Some(_)) => Ok(true),
+        Ok(None) => Ok(false),
+        Err(e) => Err(format!("Failed to read migration metadata: {e}")),
+    }
+}
+
+/// Check whether the legacy fake-profile marker indicates completion.
+async fn is_legacy_marker_complete(store: &ConfigStore) -> Result<bool, String> {
     match store.get_profile(MIGRATION_PROFILE_ID).await {
         Ok(Some(record)) => Ok(record
             .payload
@@ -215,7 +246,7 @@ async fn is_migration_complete(store: &ConfigStore) -> Result<bool, String> {
             .and_then(|v| v.as_bool())
             .unwrap_or(false)),
         Ok(None) => Ok(false),
-        Err(e) => Err(format!("Failed to read migration marker: {e}")),
+        Err(e) => Err(format!("Failed to read legacy migration marker: {e}")),
     }
 }
 
@@ -224,14 +255,24 @@ async fn record_migration_complete(store: &ConfigStore) -> Result<(), String> {
         "completed": true,
         "version": MIGRATION_VERSION,
     });
+
+    // Write the durable metadata marker first so a crash after this step
+    // does not lose completion state.
     store
-        .set_profile(&iron_core::config::ProfileInput {
-            id: MIGRATION_PROFILE_ID.to_string(),
-            schema_version: MIGRATION_VERSION,
-            payload,
+        .set_bootstrap_metadata(&BootstrapMetadataInput {
+            domain: MIGRATION_DOMAIN.to_string(),
+            key: MIGRATION_KEY.to_string(),
+            value: payload.to_string(),
         })
         .await
-        .map_err(|e| format!("Failed to record migration completion: {e}"))
+        .map_err(|e| format!("Failed to record migration completion: {e}"))?;
+
+    // Remove the legacy fake-profile marker so it does not pollute typed
+    // profile listing or diagnostics.
+    // Ignore errors here — if the old marker doesn't exist, that's fine.
+    let _ = store.delete_profile(MIGRATION_PROFILE_ID).await;
+
+    Ok(())
 }
 
 fn delete_legacy_core_keys(conn: &Connection) -> Result<(), String> {
@@ -721,7 +762,7 @@ mod tests {
             "invalid default model should be skipped"
         );
 
-        let completed = is_migration_complete(&store)
+        let completed = has_metadata_marker(&store)
             .await
             .expect("migration should record completion");
         assert!(completed);
@@ -780,5 +821,149 @@ mod tests {
 
         let configs = store.list_provider_configs().await.unwrap();
         assert_eq!(configs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn migration_converts_legacy_profile_marker_to_metadata() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Simulate a store with the old fake-profile migration marker.
+        store
+            .set_profile(&iron_core::config::ProfileInput {
+                id: MIGRATION_PROFILE_ID.to_string(),
+                schema_version: MIGRATION_VERSION,
+                payload: serde_json::json!({"completed": true, "version": 1}),
+            })
+            .await
+            .unwrap();
+
+        // The old marker should be recognized as complete.
+        assert!(is_legacy_marker_complete(&store).await.unwrap());
+
+        // Run the real migration path (not just record_migration_complete).
+        let (legacy_conn, _legacy_temp) = legacy_db_with_settings(&[]);
+        migrate_legacy_settings(&store, &legacy_conn).await.unwrap();
+
+        // Metadata marker is now present.
+        let metadata = store
+            .get_bootstrap_metadata(MIGRATION_DOMAIN, MIGRATION_KEY)
+            .await
+            .unwrap();
+        assert!(metadata.is_some());
+
+        // Old fake-profile marker is gone.
+        let old_profile = store.get_profile(MIGRATION_PROFILE_ID).await.unwrap();
+        assert!(old_profile.is_none());
+    }
+
+    #[tokio::test]
+    async fn migration_preserves_unrelated_profiles() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Insert a real user profile.
+        iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::RestoreMissing,
+        )
+        .await
+        .unwrap();
+
+        // Also insert the old migration marker.
+        store
+            .set_profile(&iron_core::config::ProfileInput {
+                id: MIGRATION_PROFILE_ID.to_string(),
+                schema_version: MIGRATION_VERSION,
+                payload: serde_json::json!({"completed": true, "version": 1}),
+            })
+            .await
+            .unwrap();
+
+        record_migration_complete(&store).await.unwrap();
+
+        // Real profiles remain.
+        let ids = store.list_profile_ids().await.unwrap();
+        assert!(ids.contains(&"explore".to_string()));
+        assert!(!ids.contains(&MIGRATION_PROFILE_ID.to_string()));
+    }
+
+    #[tokio::test]
+    async fn first_run_seeding_creates_shipped_defaults() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        let report = iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+        )
+        .await
+        .unwrap();
+
+        assert!(report
+            .created
+            .contains(&iron_core::profile::AgentProfileId::from("explore")));
+        assert!(report
+            .created
+            .contains(&iron_core::profile::AgentProfileId::from("plan")));
+        assert!(report
+            .created
+            .contains(&iron_core::profile::AgentProfileId::from("apply")));
+        assert!(report.marker_written);
+    }
+
+    #[tokio::test]
+    async fn first_run_seeding_preserves_edited_and_deleted_profiles() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // First run seeds all three defaults.
+        iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+        )
+        .await
+        .unwrap();
+
+        // Delete one profile.
+        store.delete_profile("apply").await.unwrap();
+
+        // Second run with FirstRunOnly must NOT recreate the deleted profile.
+        let report = iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+        )
+        .await
+        .unwrap();
+
+        assert!(report.created.is_empty());
+        let ids = store.list_profile_ids().await.unwrap();
+        assert!(!ids.contains(&"apply".to_string()));
+    }
+
+    #[tokio::test]
+    async fn restore_missing_recreates_deleted_defaults() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Seed defaults.
+        iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+        )
+        .await
+        .unwrap();
+
+        // Delete one.
+        store.delete_profile("plan").await.unwrap();
+
+        // RestoreMissing recreates the deleted default.
+        let report = iron_core::profile::seed_default_profiles(
+            &store,
+            iron_core::profile::DefaultProfileSeedPolicy::RestoreMissing,
+        )
+        .await
+        .unwrap();
+
+        assert!(report
+            .created
+            .contains(&iron_core::profile::AgentProfileId::from("plan")));
+        let ids = store.list_profile_ids().await.unwrap();
+        assert!(ids.contains(&"plan".to_string()));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,11 +35,21 @@ pub fn run() {
                 .unwrap_or_else(|_| std::path::PathBuf::from("."));
             let db_path = app_data_dir.join("agentiron.db");
 
-            // Open the shared iron-core config store and run one-time migration of legacy
-            // AgentIron settings. This blocks startup if credential encryption is unavailable
-            // so the user gets an actionable error instead of silent credential degradation.
-            let core_config = std::thread::spawn(move || {
+            // Shared-config initialization is best-effort: if encryption or
+            // the config store cannot be opened, the app still boots so the
+            // frontend can display an actionable, secret-safe error rather
+            // than exiting silently.
+            let shared_config_error: commands::config_management::SharedConfigError =
+                std::sync::Mutex::new(None);
+
+            let core_config_result = std::thread::spawn(move || {
                 let cipher = crate::core_config::resolve_config_cipher_sync();
+                if cipher.is_none() {
+                    return Err("Credential encryption is unavailable. \
+                         Set AGENTIRON_CONFIG_ENCRYPTION_KEY or ensure your OS keyring \
+                         is accessible, then restart AgentIron."
+                        .to_string());
+                }
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
@@ -53,18 +63,35 @@ pub fn run() {
                     crate::commands::settings::ensure_settings_schema_inner(&legacy_conn)?;
                     crate::core_config::migrate_legacy_settings(&config.store, &legacy_conn)
                         .await?;
+
+                    // Seed shipped default agent profiles non-destructively.
+                    iron_core::profile::seed_default_profiles(
+                        &config.store,
+                        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+                    )
+                    .await
+                    .map_err(|e| format!("Failed to seed default profiles: {e}"))?;
+
                     Ok::<_, String>(config)
                 })
             })
             .join()
-            .map_err(|_| "Shared config initialization panicked".to_string())?
-            .map_err(|e| format!("Failed to initialize shared config: {e}"))?;
+            .map_err(|_| "Shared config initialization panicked".to_string())?;
 
+            match core_config_result {
+                Ok(config) => {
+                    let debug_enabled = crate::debug::is_debug_mode();
+                    let core_config = std::sync::Arc::new(config);
+                    app.manage(CoreConfig::clone(&core_config));
+                    app.manage(state::AppState::new(core_config, debug_enabled));
+                }
+                Err(e) => {
+                    *shared_config_error.lock().unwrap() = Some(e);
+                }
+            }
+
+            app.manage(shared_config_error);
             commands::settings::ensure_settings_schema(app.handle())?;
-            let debug_enabled = crate::debug::is_debug_mode();
-            let core_config = std::sync::Arc::new(core_config);
-            app.manage(CoreConfig::clone(&core_config));
-            app.manage(state::AppState::new(core_config, debug_enabled));
             app.manage(commands::snip::SnipState::new());
 
             // System tray (desktop only)
@@ -127,6 +154,24 @@ pub fn run() {
             commands::oauth::get_provider_auth_status,
             commands::settings::load_settings_rows,
             commands::settings::save_setting_row,
+            commands::config_management::list_profiles,
+            commands::config_management::get_profile,
+            commands::config_management::save_profile,
+            commands::config_management::delete_profile,
+            commands::config_management::profile_impact,
+            commands::config_management::list_prompts,
+            commands::config_management::get_prompt,
+            commands::config_management::create_prompt,
+            commands::config_management::save_prompt,
+            commands::config_management::rename_prompt,
+            commands::config_management::delete_prompt,
+            commands::config_management::prompt_impact,
+            commands::config_management::list_credentials,
+            commands::config_management::set_api_key,
+            commands::config_management::delete_credential,
+            commands::config_management::get_shared_config_error,
+            commands::config_management::seed_default_profiles,
+            commands::config_management::restore_default_profiles,
             commands::snip::start_snip,
             commands::snip::capture_snip,
             commands::snip::get_snip_screenshot,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { AgentProvider } from "@context/AgentContext";
 import { ChatProvider } from "@context/ChatContext";
 import { UIProvider } from "@context/UIContext";
 import { SettingsProvider } from "@context/SettingsContext";
+import { ConfigManagementProvider } from "@context/ConfigManagementContext";
 import { McpProvider } from "@context/McpContext";
 import { NotificationProvider } from "@context/NotificationContext";
 import { SkillCatalogProvider } from "@context/SkillCatalogContext";
@@ -16,13 +17,15 @@ const App: Component = () => {
       <UIProvider>
         <NotificationProvider>
           <AgentProvider>
-            <SkillCatalogProvider>
-              <McpProvider>
-                <ChatProvider>
-                  <AppShell />
-                </ChatProvider>
-              </McpProvider>
-            </SkillCatalogProvider>
+            <ConfigManagementProvider>
+              <SkillCatalogProvider>
+                <McpProvider>
+                  <ChatProvider>
+                    <AppShell />
+                  </ChatProvider>
+                </McpProvider>
+              </SkillCatalogProvider>
+            </ConfigManagementProvider>
           </AgentProvider>
           <NotificationStack />
         </NotificationProvider>

--- a/src/components/agents/AgentsWorkspace.tsx
+++ b/src/components/agents/AgentsWorkspace.tsx
@@ -1,0 +1,142 @@
+import { Show, createSignal, type Component } from "solid-js";
+import { useUI } from "@context/UIContext";
+import { useConfigManagement } from "@context/ConfigManagementContext";
+import { ProfileList } from "@components/agents/ProfileList";
+import { PromptList } from "@components/agents/PromptList";
+import {
+  TbOutlineRefresh,
+  TbOutlineAlertTriangle,
+  TbOutlineUserCircle,
+  TbOutlineFileText,
+} from "solid-icons/tb";
+
+export const AgentsWorkspace: Component = () => {
+  const { agentsSection, setAgentsSection } = useUI();
+  const mgmt = useConfigManagement();
+
+  return (
+    <div class="flex h-full">
+      <div class="w-48 flex-shrink-0 border-r border-border-subtle p-3 space-y-1">
+        <div class="px-3 py-2 text-xs font-semibold text-text-tertiary uppercase tracking-wide">
+          Agents
+        </div>
+        <button
+          onClick={() => setAgentsSection("profiles")}
+          class={`w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+            agentsSection() === "profiles"
+              ? "bg-bg-hover text-text-primary"
+              : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+          }`}
+        >
+          <TbOutlineUserCircle size={15} />
+          <span>Profiles</span>
+        </button>
+        <button
+          onClick={() => setAgentsSection("prompts")}
+          class={`w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+            agentsSection() === "prompts"
+              ? "bg-bg-hover text-text-primary"
+              : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+          }`}
+        >
+          <TbOutlineFileText size={15} />
+          <span>Prompts</span>
+        </button>
+        <div class="pt-3">
+          <button
+            onClick={() => mgmt.refresh()}
+            disabled={mgmt.loading()}
+            class="w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors disabled:opacity-50"
+          >
+            <TbOutlineRefresh size={15} class={mgmt.loading() ? "animate-spin" : ""} />
+            <span>Refresh</span>
+          </button>
+        </div>
+      </div>
+      <div class="flex-1 overflow-y-auto p-6">
+        <div class="max-w-2xl mx-auto">
+          <Show when={mgmt.configInitError()}>
+            <SharedConfigError message={mgmt.configInitError()!} />
+          </Show>
+          <Show when={!mgmt.configInitError() && mgmt.error()}>
+            <div class="mb-4 rounded-lg border border-error-border bg-error-muted px-4 py-3 text-sm text-error">
+              {mgmt.error()}
+            </div>
+          </Show>
+          <Show when={!mgmt.configInitError() && mgmt.zeroProfiles() && !mgmt.loading()}>
+            <ZeroProfileRecovery />
+          </Show>
+          <Show
+            when={!mgmt.configInitError() && !mgmt.zeroProfiles() && !mgmt.loading()}
+            fallback={null}
+          >
+            <Show
+              when={agentsSection() === "profiles"}
+              fallback={<PromptList />}
+            >
+              <ProfileList />
+            </Show>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const SharedConfigError: Component<{ message: string }> = (props) => {
+  return (
+    <div class="rounded-lg border border-error-border bg-error-muted px-6 py-8 space-y-3">
+      <div class="flex items-center gap-2">
+        <TbOutlineAlertTriangle size={24} class="text-error" />
+        <h2 class="text-lg font-semibold text-error">Configuration unavailable</h2>
+      </div>
+      <p class="text-sm text-text-secondary">{props.message}</p>
+      <p class="text-xs text-text-tertiary">
+        Shared configuration (profiles, prompts, providers, and credentials) is blocked
+        until this is resolved. Restart AgentIron after fixing the issue.
+      </p>
+    </div>
+  );
+};
+
+const ZeroProfileRecovery: Component = () => {
+  const mgmt = useConfigManagement();
+  const [restoring, setRestoring] = createSignal(false);
+  const [restoreError, setRestoreError] = createSignal<string | null>(null);
+
+  const handleRestore = async () => {
+    setRestoring(true);
+    setRestoreError(null);
+    try {
+      await mgmt.restoreDefaults();
+    } catch (e) {
+      setRestoreError(typeof e === "string" ? e : String(e));
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  return (
+    <div class="rounded-lg border border-warning-border bg-warning-muted px-6 py-8 text-center space-y-4">
+      <div class="flex justify-center">
+        <TbOutlineAlertTriangle size={32} class="text-warning" />
+      </div>
+      <div>
+        <h2 class="text-lg font-semibold">No valid agent profiles</h2>
+        <p class="text-sm text-text-tertiary mt-1">
+          At least one valid profile is required. Restore the default profiles to continue.
+        </p>
+      </div>
+      <Show when={restoreError()}>
+        <p class="text-sm text-error" data-testid="restore-error">{restoreError()}</p>
+      </Show>
+      <button
+        onClick={handleRestore}
+        disabled={restoring()}
+        class="rounded-lg bg-accent px-4 py-2.5 text-sm text-void transition-colors hover:bg-accent-hover disabled:opacity-50"
+      >
+        {restoring() ? "Restoring..." : "Restore Default Profiles"}
+      </button>
+    </div>
+  );
+};

--- a/src/components/agents/ProfileList.tsx
+++ b/src/components/agents/ProfileList.tsx
@@ -1,0 +1,592 @@
+import {
+  For,
+  Show,
+  createSignal,
+  createMemo,
+  type Component,
+  type JSX,
+} from "solid-js";
+import { useConfigManagement, MutationError } from "@context/ConfigManagementContext";
+import { BUILTIN_TOOLS } from "@lib/tools";
+import { PROVIDER_METADATA } from "@lib/models";
+import type {
+  ManagedProfileRecordDto,
+  AgentProfileDto,
+} from "@lib/tauri/config-commands";
+import { formatDependencyEntity } from "@lib/tauri/config-commands";
+import {
+  TbOutlinePlus,
+  TbOutlineTrash,
+  TbOutlinePencil,
+  TbOutlineAlertTriangle,
+  TbOutlineDeviceFloppy,
+  TbOutlineArrowLeft,
+} from "solid-icons/tb";
+
+type EditorMode = { kind: "none" } | { kind: "create" } | { kind: "edit"; id: string };
+
+export const ProfileList: Component = () => {
+  const mgmt = useConfigManagement();
+  const [editor, setEditor] = createSignal<EditorMode>({ kind: "none" });
+  const [deleteTarget, setDeleteTarget] = createSignal<string | null>(null);
+  const [deleteError, setDeleteError] = createSignal<string | null>(null);
+  const [deleteDependents, setDeleteDependents] = createSignal<string[]>([]);
+  const [impactLoading, setImpactLoading] = createSignal(false);
+  const [impactFailed, setImpactFailed] = createSignal(false);
+
+  const readyProfiles = createMemo(() =>
+    mgmt.profiles().filter((r): r is Extract<ManagedProfileRecordDto, { status: "ready" }> =>
+      r.status === "ready"
+    )
+  );
+
+  const needsAttention = createMemo(() =>
+    mgmt.profiles().filter((r) => r.status === "needsAttention")
+  );
+
+  const startCreate = () => setEditor({ kind: "create" });
+  const startEdit = (id: string) => setEditor({ kind: "edit", id });
+  const closeEditor = () => setEditor({ kind: "none" });
+
+  const confirmDelete = async (id: string) => {
+    setDeleteTarget(id);
+    setDeleteError(null);
+    setDeleteDependents([]);
+    setImpactLoading(true);
+    setImpactFailed(false);
+    try {
+      const impact = await mgmt.profileImpact(id);
+      setDeleteDependents(
+        impact.links
+          .filter((link) => link.direction === "dependent")
+          .map((link) => formatDependencyEntity(link.entity)),
+      );
+    } catch {
+      setImpactFailed(true);
+      setDeleteError("Failed to check dependencies. Deletion is blocked until the check succeeds.");
+    } finally {
+      setImpactLoading(false);
+    }
+  };
+
+  const doDelete = async () => {
+    const id = deleteTarget();
+    if (!id) return;
+    try {
+      await mgmt.deleteProfile(id);
+      setDeleteTarget(null);
+    } catch (e) {
+      setDeleteError(String(e));
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <Show when={editor().kind === "none"}>
+        <div class="flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-text-secondary">Agent Profiles</h2>
+          <button
+            onClick={startCreate}
+            data-testid="btn-new-profile"
+            class="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs text-void hover:bg-accent-hover transition-colors"
+          >
+            <TbOutlinePlus size={14} />
+            New Profile
+          </button>
+        </div>
+
+        <Show when={mgmt.loading()}>
+          <p class="text-sm text-text-tertiary" data-testid="profile-loading">Loading...</p>
+        </Show>
+
+        <Show when={!mgmt.loading() && mgmt.profiles().length === 0}>
+          <p class="text-sm text-text-tertiary">No profiles found.</p>
+        </Show>
+
+        <div class="space-y-2" data-testid="profile-list">
+          <For each={readyProfiles()}>
+            {(record) => (
+              <div
+                data-testid={`profile-row-${record.entry.id}`}
+                class="flex items-center justify-between rounded-md border border-border-subtle px-4 py-3"
+              >
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-medium text-text-primary">
+                      {record.entry.profile.name}
+                    </span>
+                    <span class="text-xs text-text-tertiary">{record.entry.id}</span>
+                  </div>
+                  <div class="mt-0.5 flex items-center gap-2 text-xs text-text-tertiary">
+                    <Show when={record.entry.profile.kind === "managed"} fallback={
+                      <span>Runtime default provider</span>
+                    }>
+                      <span>{record.entry.profile.providerSlug}/{record.entry.profile.model}</span>
+                    </Show>
+                    <Show when={record.entry.profile.identityPrompt}>
+                      <span class="text-text-quaternary">| custom identity</span>
+                    </Show>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button
+                    onClick={() => startEdit(record.entry.id)}
+                    data-testid={`btn-edit-${record.entry.id}`}
+                    class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                    title="Edit"
+                  >
+                    <TbOutlinePencil size={14} />
+                  </button>
+                  <button
+                    onClick={() => confirmDelete(record.entry.id)}
+                    data-testid={`btn-delete-${record.entry.id}`}
+                    class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-error"
+                    title="Delete"
+                  >
+                    <TbOutlineTrash size={14} />
+                  </button>
+                </div>
+              </div>
+            )}
+          </For>
+
+          <For each={needsAttention()}>
+            {(record) => (
+              <div
+                data-testid={`profile-row-${record.id}`}
+                class="flex items-center justify-between rounded-md border border-warning-border bg-warning-muted px-4 py-3"
+              >
+                <div class="flex items-center gap-2">
+                  <TbOutlineAlertTriangle size={14} class="text-warning" />
+                  <span class="text-sm font-medium text-text-primary">{record.id}</span>
+                  <span class="text-xs text-warning">Needs attention</span>
+                </div>
+                <Show when={record.diagnostics.length > 0}>
+                  <div class="text-xs text-text-tertiary">
+                    {record.diagnostics.map((d) => d.message).join("; ")}
+                  </div>
+                </Show>
+                <div class="flex items-center gap-1">
+                  <Show when={record.decoded}>
+                    <button
+                      onClick={() => startEdit(record.id)}
+                      data-testid={`btn-edit-${record.id}`}
+                      class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                      title="Edit"
+                    >
+                      <TbOutlinePencil size={14} />
+                    </button>
+                  </Show>
+                  <button
+                    onClick={() => confirmDelete(record.id)}
+                    data-testid={`btn-delete-${record.id}`}
+                    class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-error"
+                  >
+                    <TbOutlineTrash size={14} />
+                  </button>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={editor().kind !== "none"}>
+        <ProfileEditor
+          mode={editor()}
+          onClose={closeEditor}
+          onSave={async (id, profile) => {
+            await mgmt.saveProfile(id, profile);
+            closeEditor();
+          }}
+        />
+      </Show>
+
+      <Show when={deleteTarget()}>
+        <DeleteDialog
+          id={deleteTarget()!}
+          dependents={deleteDependents()}
+          error={deleteError()}
+          impactLoading={impactLoading()}
+          impactFailed={impactFailed()}
+          onCancel={() => { setDeleteTarget(null); setDeleteError(null); setImpactFailed(false); }}
+          onConfirm={doDelete}
+        />
+      </Show>
+    </div>
+  );
+};
+
+// ── Profile Editor ──
+
+const ProfileEditor: Component<{
+  mode: EditorMode;
+  onClose: () => void;
+  onSave: (id: string, profile: AgentProfileDto) => Promise<void>;
+}> = (props) => {
+  const mgmt = useConfigManagement();
+  const [saving, setSaving] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const existing = createMemo(() => {
+    if (props.mode.kind !== "edit") return null;
+    for (const r of mgmt.profiles()) {
+      if (r.status === "ready" && r.entry.id === props.mode.id) {
+        return r.entry.profile;
+      }
+      if (r.status === "needsAttention" && r.id === props.mode.id && r.decoded) {
+        return r.decoded;
+      }
+    }
+    return null;
+  });
+
+  const [id, setId] = createSignal(props.mode.kind === "edit" ? props.mode.id : "");
+  const [name, setName] = createSignal(existing()?.name ?? "");
+  const [providerKind, setProviderKind] = createSignal<"runtimeDefault" | "managed">(
+    existing()?.kind ?? "runtimeDefault"
+  );
+  const [providerSlug, setProviderSlug] = createSignal(existing()?.providerSlug ?? "");
+  const [model, setModel] = createSignal(existing()?.model ?? "");
+  const [toolFilterKind, setToolFilterKind] = createSignal(
+    existing()?.tools.kind ?? "inherit"
+  );
+  const [toolNames, setToolNames] = createSignal(
+    existing()?.tools.kind === "allow" || existing()?.tools.kind === "deny"
+      ? ((existing()?.tools as { names: string[] })?.names ?? []).join(", ")
+      : ""
+  );
+  const [skillFilterKind, setSkillFilterKind] = createSignal(
+    existing()?.skills.kind ?? "inherit"
+  );
+  const [skillNames, setSkillNames] = createSignal(
+    existing()?.skills.kind === "allow"
+      ? ((existing()?.skills as { names: string[] })?.names ?? []).join(", ")
+      : ""
+  );
+  const [approval, setApproval] = createSignal<"perTool" | "autoApprove">(
+    existing()?.approval ?? "perTool"
+  );
+  const [identityPrompt, setIdentityPrompt] = createSignal(
+    existing()?.identityPrompt ?? ""
+  );
+
+  const isEdit = () => props.mode.kind === "edit";
+
+  const buildDto = (): AgentProfileDto => {
+    const tools =
+      toolFilterKind() === "inherit"
+        ? { kind: "inherit" as const }
+        : toolFilterKind() === "allow"
+          ? { kind: "allow" as const, names: toolNames().split(",").map((s) => s.trim()).filter(Boolean) }
+          : { kind: "deny" as const, names: toolNames().split(",").map((s) => s.trim()).filter(Boolean) };
+
+    const skills =
+      skillFilterKind() === "inherit"
+        ? { kind: "inherit" as const }
+        : skillFilterKind() === "none"
+          ? { kind: "none" as const }
+          : { kind: "allow" as const, names: skillNames().split(",").map((s) => s.trim()).filter(Boolean) };
+
+    return {
+      name: name(),
+      kind: providerKind(),
+      ...(providerKind() === "managed" ? { providerSlug: providerSlug(), model: model() } : {}),
+      tools,
+      skills,
+      approval: approval(),
+      identityPrompt: identityPrompt().trim() || undefined,
+    };
+  };
+
+  const handleSave = async () => {
+    if (!name().trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (providerKind() === "managed" && (!providerSlug().trim() || !model().trim())) {
+      setError("Provider and model are required for managed profiles");
+      return;
+    }
+    if (!isEdit() && !id().trim()) {
+      setError("Profile ID is required");
+      return;
+    }
+
+    if (!isEdit()) {
+      const trimmedId = id().trim();
+      const exists = mgmt.profiles().some(
+        (r) => (r.status === "ready" ? r.entry.id : r.id) === trimmedId
+      );
+      if (exists) {
+        setError("A profile with this ID already exists");
+        return;
+      }
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await props.onSave(id().trim(), buildDto());
+    } catch (e) {
+      if (e instanceof MutationError) {
+        const dto = e.dto;
+        if (dto.field === "providerSlug") {
+          setError(`Provider: ${dto.message}`);
+        } else if (dto.field === "model") {
+          setError(`Model: ${dto.message}`);
+        } else {
+          setError(dto.message);
+        }
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="space-y-4" data-testid="profile-editor">
+      <div class="flex items-center gap-2">
+        <button
+          onClick={props.onClose}
+          class="rounded p-1 text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+          data-testid="btn-cancel-edit"
+        >
+          <TbOutlineArrowLeft size={16} />
+        </button>
+        <h2 class="text-sm font-semibold text-text-secondary">
+          {isEdit() ? "Edit Profile" : "New Profile"}
+        </h2>
+      </div>
+
+      <Show when={error()}>
+        <div class="rounded-lg border border-error-border bg-error-muted px-4 py-2 text-sm text-error" data-testid="form-error">
+          {error()}
+        </div>
+      </Show>
+
+      <div class="space-y-3">
+        <Show when={!isEdit()}>
+          <Field label="Profile ID">
+            <input
+              data-testid="field-id"
+              value={id()}
+              onInput={(e) => setId(e.currentTarget.value)}
+              placeholder="my-profile"
+              class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+            />
+          </Field>
+        </Show>
+
+        <Field label="Name">
+          <input
+            data-testid="field-name"
+            value={name()}
+            onInput={(e) => setName(e.currentTarget.value)}
+            placeholder="My Profile"
+            class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          />
+        </Field>
+
+        <Field label="Provider">
+          <div class="flex gap-4">
+            <label class="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                checked={providerKind() === "runtimeDefault"}
+                onChange={() => setProviderKind("runtimeDefault")}
+              />
+              Runtime default
+            </label>
+            <label class="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                checked={providerKind() === "managed"}
+                onChange={() => setProviderKind("managed")}
+              />
+              Managed
+            </label>
+          </div>
+        </Field>
+
+        <Show when={providerKind() === "managed"}>
+          <Field label="Provider Slug">
+            <input
+              data-testid="field-provider"
+              value={providerSlug()}
+              onInput={(e) => setProviderSlug(e.currentTarget.value)}
+              placeholder="openai"
+              class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+            />
+            <div class="text-xs text-text-tertiary mt-1">
+              Suggestions: {PROVIDER_METADATA.map((p) => p.id).join(", ")}
+            </div>
+          </Field>
+          <Field label="Model">
+            <input
+              data-testid="field-model"
+              value={model()}
+              onInput={(e) => setModel(e.currentTarget.value)}
+              placeholder="gpt-4o"
+              class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+            />
+          </Field>
+        </Show>
+
+        <Field label="Tool Filter">
+          <select
+            data-testid="field-tools"
+            value={toolFilterKind()}
+            onChange={(e) => setToolFilterKind(e.currentTarget.value as "inherit" | "allow" | "deny")}
+            class="rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          >
+            <option value="inherit">Inherit all tools</option>
+            <option value="allow">Allow specific tools</option>
+            <option value="deny">Deny specific tools</option>
+          </select>
+          <Show when={toolFilterKind() !== "inherit"}>
+            <input
+              data-testid="field-tool-names"
+              value={toolNames()}
+              onInput={(e) => setToolNames(e.currentTarget.value)}
+              placeholder="read, write, bash"
+              class="mt-2 w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+            />
+            <div class="text-xs text-text-tertiary mt-1">
+              Known tools: {BUILTIN_TOOLS.map((t) => t.id).join(", ")}
+            </div>
+          </Show>
+        </Field>
+
+        <Field label="Skill Filter">
+          <select
+            data-testid="field-skills"
+            value={skillFilterKind()}
+            onChange={(e) => setSkillFilterKind(e.currentTarget.value as "inherit" | "allow" | "none")}
+            class="rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          >
+            <option value="inherit">Inherit skills</option>
+            <option value="allow">Allow specific skills</option>
+            <option value="none">No skills</option>
+          </select>
+          <Show when={skillFilterKind() === "allow"}>
+            <input
+              data-testid="field-skill-names"
+              value={skillNames()}
+              onInput={(e) => setSkillNames(e.currentTarget.value)}
+              placeholder="skill-a, skill-b"
+              class="mt-2 w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+            />
+          </Show>
+        </Field>
+
+        <Field label="Approval Policy">
+          <select
+            data-testid="field-approval"
+            value={approval()}
+            onChange={(e) => setApproval(e.currentTarget.value as "perTool" | "autoApprove")}
+            class="rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          >
+            <option value="perTool">Per-tool approval</option>
+            <option value="autoApprove">Auto-approve all tool calls</option>
+          </select>
+        </Field>
+
+        <Field label="Identity Prompt (optional)">
+          <textarea
+            data-testid="field-identity"
+            value={identityPrompt()}
+            onInput={(e) => setIdentityPrompt(e.currentTarget.value)}
+            placeholder="You are a helpful assistant..."
+            rows={3}
+            class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          />
+        </Field>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <button
+          onClick={handleSave}
+          disabled={saving()}
+          data-testid="btn-save"
+          class="flex items-center gap-1.5 rounded-md bg-accent px-4 py-2 text-sm text-void hover:bg-accent-hover disabled:opacity-50"
+        >
+          <TbOutlineDeviceFloppy size={14} />
+          {saving() ? "Saving..." : "Save"}
+        </button>
+        <button
+          onClick={props.onClose}
+          data-testid="btn-cancel"
+          class="rounded-md px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ── Delete Dialog ──
+
+const DeleteDialog: Component<{
+  id: string;
+  dependents: string[];
+  error: string | null;
+  impactLoading: boolean;
+  impactFailed: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}> = (props) => {
+  const canDelete = () =>
+    props.dependents.length === 0 && !props.impactLoading && !props.impactFailed;
+
+  return (
+    <div class="fixed inset-0 flex items-center justify-center bg-black/50" data-testid="delete-dialog">
+      <div class="max-w-sm rounded-lg bg-bg-secondary p-6 shadow-xl">
+        <h3 class="text-lg font-semibold">Delete profile "{props.id}"?</h3>
+        <Show when={props.impactLoading}>
+          <p class="mt-2 text-sm text-text-tertiary">Checking dependencies...</p>
+        </Show>
+        <Show when={props.dependents.length > 0}>
+          <p class="mt-2 text-sm text-warning">
+            Referenced by prompts: {props.dependents.join(", ")}
+          </p>
+          <p class="text-sm text-text-tertiary">
+            Resolve the references before deleting.
+          </p>
+        </Show>
+        <Show when={props.error}>
+          <p class="mt-2 text-sm text-error" data-testid="delete-error">{props.error}</p>
+        </Show>
+        <div class="mt-4 flex justify-end gap-2">
+          <button
+            onClick={props.onCancel}
+            class="rounded-md px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover"
+          >
+            Cancel
+          </button>
+          <Show when={canDelete()}>
+            <button
+              onClick={props.onConfirm}
+              data-testid="btn-confirm-delete"
+              class="rounded-md bg-error px-4 py-2 text-sm text-void hover:bg-error-hover"
+            >
+              Delete
+            </button>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── Helpers ──
+
+const Field: Component<{ label: string; children: JSX.Element }> = (props) => (
+  <div>
+    <label class="mb-1 block text-xs font-medium text-text-secondary">{props.label}</label>
+    {props.children}
+  </div>
+);

--- a/src/components/agents/ProfileList.tsx
+++ b/src/components/agents/ProfileList.tsx
@@ -33,6 +33,7 @@ export const ProfileList: Component = () => {
   const [deleteDependents, setDeleteDependents] = createSignal<string[]>([]);
   const [impactLoading, setImpactLoading] = createSignal(false);
   const [impactFailed, setImpactFailed] = createSignal(false);
+  const [deleting, setDeleting] = createSignal(false);
 
   const readyProfiles = createMemo(() =>
     mgmt.profiles().filter((r): r is Extract<ManagedProfileRecordDto, { status: "ready" }> =>
@@ -71,12 +72,15 @@ export const ProfileList: Component = () => {
 
   const doDelete = async () => {
     const id = deleteTarget();
-    if (!id) return;
+    if (!id || deleting()) return;
+    setDeleting(true);
     try {
       await mgmt.deleteProfile(id);
       setDeleteTarget(null);
     } catch (e) {
       setDeleteError(String(e));
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -209,6 +213,7 @@ export const ProfileList: Component = () => {
           error={deleteError()}
           impactLoading={impactLoading()}
           impactFailed={impactFailed()}
+          deleting={deleting()}
           onCancel={() => { setDeleteTarget(null); setDeleteError(null); setImpactFailed(false); }}
           onConfirm={doDelete}
         />
@@ -369,8 +374,9 @@ const ProfileEditor: Component<{
 
       <div class="space-y-3">
         <Show when={!isEdit()}>
-          <Field label="Profile ID">
+          <Field label="Profile ID" labelFor="profile-id">
             <input
+              id="profile-id"
               data-testid="field-id"
               value={id()}
               onInput={(e) => setId(e.currentTarget.value)}
@@ -380,8 +386,9 @@ const ProfileEditor: Component<{
           </Field>
         </Show>
 
-        <Field label="Name">
+        <Field label="Name" labelFor="profile-name">
           <input
+            id="profile-name"
             data-testid="field-name"
             value={name()}
             onInput={(e) => setName(e.currentTarget.value)}
@@ -390,7 +397,8 @@ const ProfileEditor: Component<{
           />
         </Field>
 
-        <Field label="Provider">
+        <fieldset>
+          <legend class="mb-1 block text-xs font-medium text-text-secondary">Provider</legend>
           <div class="flex gap-4">
             <label class="flex items-center gap-1.5 text-sm">
               <input
@@ -409,11 +417,12 @@ const ProfileEditor: Component<{
               Managed
             </label>
           </div>
-        </Field>
+        </fieldset>
 
         <Show when={providerKind() === "managed"}>
-          <Field label="Provider Slug">
+          <Field label="Provider Slug" labelFor="profile-provider">
             <input
+              id="profile-provider"
               data-testid="field-provider"
               value={providerSlug()}
               onInput={(e) => setProviderSlug(e.currentTarget.value)}
@@ -424,8 +433,9 @@ const ProfileEditor: Component<{
               Suggestions: {PROVIDER_METADATA.map((p) => p.id).join(", ")}
             </div>
           </Field>
-          <Field label="Model">
+          <Field label="Model" labelFor="profile-model">
             <input
+              id="profile-model"
               data-testid="field-model"
               value={model()}
               onInput={(e) => setModel(e.currentTarget.value)}
@@ -435,8 +445,9 @@ const ProfileEditor: Component<{
           </Field>
         </Show>
 
-        <Field label="Tool Filter">
+        <Field label="Tool Filter" labelFor="profile-tools">
           <select
+            id="profile-tools"
             data-testid="field-tools"
             value={toolFilterKind()}
             onChange={(e) => setToolFilterKind(e.currentTarget.value as "inherit" | "allow" | "deny")}
@@ -449,6 +460,7 @@ const ProfileEditor: Component<{
           <Show when={toolFilterKind() !== "inherit"}>
             <input
               data-testid="field-tool-names"
+              aria-label="Tool names"
               value={toolNames()}
               onInput={(e) => setToolNames(e.currentTarget.value)}
               placeholder="read, write, bash"
@@ -460,8 +472,9 @@ const ProfileEditor: Component<{
           </Show>
         </Field>
 
-        <Field label="Skill Filter">
+        <Field label="Skill Filter" labelFor="profile-skills">
           <select
+            id="profile-skills"
             data-testid="field-skills"
             value={skillFilterKind()}
             onChange={(e) => setSkillFilterKind(e.currentTarget.value as "inherit" | "allow" | "none")}
@@ -474,6 +487,7 @@ const ProfileEditor: Component<{
           <Show when={skillFilterKind() === "allow"}>
             <input
               data-testid="field-skill-names"
+              aria-label="Skill names"
               value={skillNames()}
               onInput={(e) => setSkillNames(e.currentTarget.value)}
               placeholder="skill-a, skill-b"
@@ -482,8 +496,9 @@ const ProfileEditor: Component<{
           </Show>
         </Field>
 
-        <Field label="Approval Policy">
+        <Field label="Approval Policy" labelFor="profile-approval">
           <select
+            id="profile-approval"
             data-testid="field-approval"
             value={approval()}
             onChange={(e) => setApproval(e.currentTarget.value as "perTool" | "autoApprove")}
@@ -494,8 +509,9 @@ const ProfileEditor: Component<{
           </select>
         </Field>
 
-        <Field label="Identity Prompt (optional)">
+        <Field label="Identity Prompt (optional)" labelFor="profile-identity">
           <textarea
+            id="profile-identity"
             data-testid="field-identity"
             value={identityPrompt()}
             onInput={(e) => setIdentityPrompt(e.currentTarget.value)}
@@ -536,6 +552,7 @@ const DeleteDialog: Component<{
   error: string | null;
   impactLoading: boolean;
   impactFailed: boolean;
+  deleting: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }> = (props) => {
@@ -570,10 +587,11 @@ const DeleteDialog: Component<{
           <Show when={canDelete()}>
             <button
               onClick={props.onConfirm}
+              disabled={props.deleting}
               data-testid="btn-confirm-delete"
-              class="rounded-md bg-error px-4 py-2 text-sm text-void hover:bg-error-hover"
+              class="rounded-md bg-error px-4 py-2 text-sm text-void hover:bg-error-hover disabled:opacity-50"
             >
-              Delete
+              {props.deleting ? "Deleting..." : "Delete"}
             </button>
           </Show>
         </div>
@@ -584,9 +602,9 @@ const DeleteDialog: Component<{
 
 // ── Helpers ──
 
-const Field: Component<{ label: string; children: JSX.Element }> = (props) => (
+const Field: Component<{ label: string; labelFor: string; children: JSX.Element }> = (props) => (
   <div>
-    <label class="mb-1 block text-xs font-medium text-text-secondary">{props.label}</label>
+    <label for={props.labelFor} class="mb-1 block text-xs font-medium text-text-secondary">{props.label}</label>
     {props.children}
   </div>
 );

--- a/src/components/agents/PromptList.tsx
+++ b/src/components/agents/PromptList.tsx
@@ -1,0 +1,468 @@
+import {
+  For,
+  Show,
+  createSignal,
+  createMemo,
+  type Component,
+  type JSX,
+} from "solid-js";
+import { useConfigManagement, MutationError } from "@context/ConfigManagementContext";
+import type {
+  ManagedPromptRecordDto,
+  ManagedProfileRecordDto,
+  StoredPromptDto,
+} from "@lib/tauri/config-commands";
+import { formatDependencyEntity } from "@lib/tauri/config-commands";
+import {
+  TbOutlinePlus,
+  TbOutlineTrash,
+  TbOutlinePencil,
+  TbOutlineAlertTriangle,
+  TbOutlineDeviceFloppy,
+  TbOutlineArrowLeft,
+} from "solid-icons/tb";
+
+type EditorMode = { kind: "none" } | { kind: "create" } | { kind: "edit"; id: string };
+
+export const PromptList: Component = () => {
+  const mgmt = useConfigManagement();
+  const [editor, setEditor] = createSignal<EditorMode>({ kind: "none" });
+  const [deleteTarget, setDeleteTarget] = createSignal<string | null>(null);
+  const [deleteError, setDeleteError] = createSignal<string | null>(null);
+  const [deleteDependents, setDeleteDependents] = createSignal<string[]>([]);
+  const [impactLoading, setImpactLoading] = createSignal(false);
+  const [impactFailed, setImpactFailed] = createSignal(false);
+
+  const readyPrompts = createMemo(() =>
+    mgmt.prompts().filter((r): r is Extract<ManagedPromptRecordDto, { status: "ready" }> =>
+      r.status === "ready"
+    )
+  );
+
+  const needsAttention = createMemo(() =>
+    mgmt.prompts().filter((r) => r.status === "needsAttention")
+  );
+
+  const profileNameById = (id: string | undefined): string | null => {
+    if (!id) return null;
+    const record = mgmt.profiles().find((r) => r.status === "ready" && r.entry.id === id);
+    return record && record.status === "ready" ? record.entry.profile.name : id;
+  };
+
+  const confirmDelete = async (id: string) => {
+    setDeleteTarget(id);
+    setDeleteError(null);
+    setDeleteDependents([]);
+    setImpactLoading(true);
+    setImpactFailed(false);
+    try {
+      const impact = await mgmt.promptImpact(id);
+      setDeleteDependents(
+        impact.links
+          .filter((link) => link.direction === "dependent")
+          .map((link) => formatDependencyEntity(link.entity)),
+      );
+    } catch {
+      setImpactFailed(true);
+      setDeleteError("Failed to check dependencies. Deletion is blocked until the check succeeds.");
+    } finally {
+      setImpactLoading(false);
+    }
+  };
+
+  const doDelete = async () => {
+    const id = deleteTarget();
+    if (!id) return;
+    try {
+      await mgmt.deletePrompt(id);
+      setDeleteTarget(null);
+    } catch (e) {
+      setDeleteError(String(e));
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <Show when={editor().kind === "none"}>
+        <div class="flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-text-secondary">Stored Prompts</h2>
+          <button
+            onClick={() => setEditor({ kind: "create" })}
+            data-testid="btn-new-prompt"
+            class="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs text-void hover:bg-accent-hover transition-colors"
+          >
+            <TbOutlinePlus size={14} />
+            New Prompt
+          </button>
+        </div>
+
+        <Show when={mgmt.loading()}>
+          <p class="text-sm text-text-tertiary" data-testid="prompt-loading">Loading...</p>
+        </Show>
+
+        <Show when={!mgmt.loading() && mgmt.prompts().length === 0}>
+          <p class="text-sm text-text-tertiary">No prompts found.</p>
+        </Show>
+
+        <div class="space-y-2" data-testid="prompt-list">
+          <For each={readyPrompts()}>
+            {(record) => (
+              <div
+                data-testid={`prompt-row-${record.entry.id}`}
+                class="flex items-center justify-between rounded-md border border-border-subtle px-4 py-3"
+              >
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-medium text-text-primary">
+                      {record.entry.prompt.displayName}
+                    </span>
+                    <Show when={record.entry.identityState === "needsRename"}>
+                      <span class="text-xs text-warning">Needs rename</span>
+                    </Show>
+                  </div>
+                  <div class="mt-0.5 flex items-center gap-2 text-xs text-text-tertiary">
+                    <Show when={record.entry.prompt.profile}>
+                      <span>{"-> "}{profileNameById(record.entry.prompt.profile)}</span>
+                    </Show>
+                    <Show when={record.entry.prompt.skills.length > 0}>
+                      <span>skills: {record.entry.prompt.skills.join(", ")}</span>
+                    </Show>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button
+                    onClick={() => setEditor({ kind: "edit", id: record.entry.id })}
+                    data-testid={`btn-edit-prompt-${record.entry.id}`}
+                    class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                    title="Edit"
+                  >
+                    <TbOutlinePencil size={14} />
+                  </button>
+                  <button
+                    onClick={() => confirmDelete(record.entry.id)}
+                    data-testid={`btn-delete-prompt-${record.entry.id}`}
+                    class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-error"
+                    title="Delete"
+                  >
+                    <TbOutlineTrash size={14} />
+                  </button>
+                </div>
+              </div>
+            )}
+          </For>
+
+          <For each={needsAttention()}>
+            {(record) => (
+              <div
+                data-testid={`prompt-row-${record.id}`}
+                class="flex items-center justify-between rounded-md border border-warning-border bg-warning-muted px-4 py-3"
+              >
+                <div class="flex items-center gap-2">
+                  <TbOutlineAlertTriangle size={14} class="text-warning" />
+                  <span class="text-sm font-medium text-text-primary">{record.id}</span>
+                  <span class="text-xs text-warning">Needs attention</span>
+                </div>
+                <Show when={record.diagnostics.length > 0}>
+                  <div class="text-xs text-text-tertiary">
+                    {record.diagnostics.map((d) => d.message).join("; ")}
+                  </div>
+                </Show>
+                <div class="flex items-center gap-1">
+                  <Show when={record.decoded}>
+                    <button
+                      onClick={() => setEditor({ kind: "edit", id: record.id })}
+                      data-testid={`btn-edit-prompt-${record.id}`}
+                      class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                      title="Edit"
+                    >
+                      <TbOutlinePencil size={14} />
+                    </button>
+                  </Show>
+                  <button
+                    onClick={() => confirmDelete(record.id)}
+                    data-testid={`btn-delete-prompt-${record.id}`}
+                    class="rounded p-1.5 text-text-secondary hover:bg-bg-hover hover:text-error"
+                  >
+                    <TbOutlineTrash size={14} />
+                  </button>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={editor().kind !== "none"}>
+        <PromptEditor
+          mode={editor()}
+          onClose={() => setEditor({ kind: "none" })}
+          onSave={async (id, prompt, isNew) => {
+            if (isNew) {
+              await mgmt.createPrompt({
+                displayName: prompt.displayName,
+                instructions: prompt.instructions,
+                skills: prompt.skills,
+                profile: prompt.profile,
+              });
+            } else {
+              await mgmt.savePrompt(id, prompt);
+            }
+            setEditor({ kind: "none" });
+          }}
+        />
+      </Show>
+
+      <Show when={deleteTarget()}>
+        <DeleteDialog
+          id={deleteTarget()!}
+          dependents={deleteDependents()}
+          error={deleteError()}
+          impactLoading={impactLoading()}
+          impactFailed={impactFailed()}
+          onCancel={() => { setDeleteTarget(null); setDeleteError(null); setImpactFailed(false); }}
+          onConfirm={doDelete}
+        />
+      </Show>
+    </div>
+  );
+};
+
+// ── Prompt Editor ──
+
+const PromptEditor: Component<{
+  mode: EditorMode;
+  onClose: () => void;
+  onSave: (id: string, prompt: StoredPromptDto, isNew: boolean) => Promise<void>;
+}> = (props) => {
+  const mgmt = useConfigManagement();
+  const [saving, setSaving] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const existing = createMemo(() => {
+    if (props.mode.kind !== "edit") return null;
+    for (const r of mgmt.prompts()) {
+      if (r.status === "ready" && r.entry.id === props.mode.id) {
+        return r.entry.prompt;
+      }
+      if (r.status === "needsAttention" && r.id === props.mode.id && r.decoded) {
+        return r.decoded;
+      }
+    }
+    return null;
+  });
+
+  const [displayName, setDisplayName] = createSignal(existing()?.displayName ?? "");
+  const [instructions, setInstructions] = createSignal(existing()?.instructions ?? "");
+  const [skills, setSkills] = createSignal(
+    existing()?.skills.join(", ") ?? ""
+  );
+  const [profile, setProfile] = createSignal(existing()?.profile ?? "");
+
+  const isEdit = () => props.mode.kind === "edit";
+
+  const readyProfileOptions = createMemo(() => {
+    return mgmt
+      .profiles()
+      .filter(
+        (r): r is Extract<ManagedProfileRecordDto, { status: "ready" }> =>
+          r.status === "ready",
+      )
+      .map((r) => ({ id: r.entry.id, name: r.entry.profile.name }));
+  });
+
+  const buildDto = (): StoredPromptDto => ({
+    displayName: displayName(),
+    normalizedName: existing()?.normalizedName ?? "",
+    instructions: instructions(),
+    skills: skills().split(",").map((s) => s.trim()).filter(Boolean),
+    profile: profile().trim() || undefined,
+  });
+
+  const handleSave = async () => {
+    if (!displayName().trim()) {
+      setError("Display name is required");
+      return;
+    }
+    if (!instructions().trim()) {
+      setError("Instructions are required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const id = isEdit() ? (props.mode as { kind: "edit"; id: string }).id : "";
+      await props.onSave(id, buildDto(), !isEdit());
+    } catch (e) {
+      if (e instanceof MutationError) {
+        const dto = e.dto;
+        if (dto.field === "displayName") {
+          setError(`Name: ${dto.message}`);
+        } else {
+          setError(dto.message);
+        }
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="space-y-4" data-testid="prompt-editor">
+      <div class="flex items-center gap-2">
+        <button
+          onClick={props.onClose}
+          class="rounded p-1 text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+          data-testid="btn-cancel-edit-prompt"
+        >
+          <TbOutlineArrowLeft size={16} />
+        </button>
+        <h2 class="text-sm font-semibold text-text-secondary">
+          {isEdit() ? "Edit Prompt" : "New Prompt"}
+        </h2>
+      </div>
+
+      <Show when={error()}>
+        <div class="rounded-lg border border-error-border bg-error-muted px-4 py-2 text-sm text-error" data-testid="form-error">
+          {error()}
+        </div>
+      </Show>
+
+      <div class="space-y-3">
+        <Field label="Display Name">
+          <input
+            data-testid="field-display-name"
+            value={displayName()}
+            onInput={(e) => setDisplayName(e.currentTarget.value)}
+            placeholder="Check Email"
+            class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          />
+        </Field>
+
+        <Field label="Instructions">
+          <textarea
+            data-testid="field-instructions"
+            value={instructions()}
+            onInput={(e) => setInstructions(e.currentTarget.value)}
+            placeholder="Check the user's email and summarize unread messages."
+            rows={4}
+            class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          />
+        </Field>
+
+        <Field label="Requested Skills (comma-separated)">
+          <input
+            data-testid="field-skills"
+            value={skills()}
+            onInput={(e) => setSkills(e.currentTarget.value)}
+            placeholder="email-reader, summarizer"
+            class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          />
+          <div class="text-xs text-text-tertiary mt-1">
+            Unknown skill identifiers are preserved for cross-machine compatibility.
+          </div>
+        </Field>
+
+        <Field label="Profile Assignment (optional)">
+          <select
+            data-testid="field-profile"
+            value={profile()}
+            onChange={(e) => setProfile(e.currentTarget.value)}
+            class="w-full rounded-md border border-border-subtle bg-bg-primary px-3 py-2 text-sm"
+          >
+            <option value="">None</option>
+            <For each={readyProfileOptions()}>
+              {(p) => (
+                <option value={p.id}>{p.name} ({p.id})</option>
+              )}
+            </For>
+          </select>
+        </Field>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <button
+          onClick={handleSave}
+          disabled={saving()}
+          data-testid="btn-save-prompt"
+          class="flex items-center gap-1.5 rounded-md bg-accent px-4 py-2 text-sm text-void hover:bg-accent-hover disabled:opacity-50"
+        >
+          <TbOutlineDeviceFloppy size={14} />
+          {saving() ? "Saving..." : "Save"}
+        </button>
+        <button
+          onClick={props.onClose}
+          data-testid="btn-cancel-prompt"
+          class="rounded-md px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ── Delete Dialog ──
+
+const DeleteDialog: Component<{
+  id: string;
+  dependents: string[];
+  error: string | null;
+  impactLoading: boolean;
+  impactFailed: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}> = (props) => {
+  const canDelete = () =>
+    props.dependents.length === 0 && !props.impactLoading && !props.impactFailed;
+
+  return (
+    <div class="fixed inset-0 flex items-center justify-center bg-black/50" data-testid="prompt-delete-dialog">
+      <div class="max-w-sm rounded-lg bg-bg-secondary p-6 shadow-xl">
+        <h3 class="text-lg font-semibold">Delete prompt "{props.id}"?</h3>
+        <Show when={props.impactLoading}>
+          <p class="mt-2 text-sm text-text-tertiary">Checking dependencies...</p>
+        </Show>
+      <Show when={props.dependents.length > 0}>
+        <p class="mt-2 text-sm text-warning">
+          Referenced by: {props.dependents.join(", ")}
+        </p>
+        <p class="text-sm text-text-tertiary">
+          Resolve the references before deleting.
+        </p>
+      </Show>
+      <Show when={props.error}>
+        <p class="mt-2 text-sm text-error" data-testid="prompt-delete-error">{props.error}</p>
+      </Show>
+      <div class="mt-4 flex justify-end gap-2">
+        <button
+          onClick={props.onCancel}
+          class="rounded-md px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover"
+        >
+          Cancel
+        </button>
+        <Show when={canDelete()}>
+          <button
+            onClick={props.onConfirm}
+            data-testid="btn-confirm-delete-prompt"
+            class="rounded-md bg-error px-4 py-2 text-sm text-void hover:bg-error-hover"
+          >
+            Delete
+          </button>
+        </Show>
+      </div>
+    </div>
+  </div>
+);
+}
+
+// ── Helpers ──
+
+const Field: Component<{ label: string; children: JSX.Element }> = (props) => (
+  <div>
+    <label class="mb-1 block text-xs font-medium text-text-secondary">{props.label}</label>
+    {props.children}
+  </div>
+);

--- a/src/components/agents/PromptList.tsx
+++ b/src/components/agents/PromptList.tsx
@@ -205,7 +205,42 @@ export const PromptList: Component = () => {
                 profile: prompt.profile,
               });
             } else {
-              await mgmt.savePrompt(id, prompt);
+              const currentRecord = mgmt.prompts().find((record) =>
+                record.status === "ready" ? record.entry.id === id : record.id === id
+              );
+              const currentPrompt = currentRecord?.status === "ready"
+                ? currentRecord.entry.prompt
+                : currentRecord?.decoded;
+              if (currentPrompt && currentPrompt.displayName !== prompt.displayName) {
+                const nonIdentityChanged =
+                  currentPrompt.instructions !== prompt.instructions ||
+                  currentPrompt.profile !== prompt.profile ||
+                  currentPrompt.skills.length !== prompt.skills.length ||
+                  currentPrompt.skills.some((skill, index) => skill !== prompt.skills[index]);
+                if (nonIdentityChanged) {
+                  await mgmt.savePrompt(id, {
+                    ...prompt,
+                    displayName: currentPrompt.displayName,
+                    normalizedName: currentPrompt.normalizedName,
+                  });
+                }
+                try {
+                  await mgmt.renamePrompt(id, prompt.displayName);
+                } catch (renameError) {
+                  if (nonIdentityChanged) {
+                    try {
+                      await mgmt.savePrompt(id, currentPrompt);
+                    } catch (rollbackError) {
+                      throw new Error(
+                        `Rename failed (${String(renameError)}), and the other prompt changes could not be rolled back (${String(rollbackError)}).`,
+                      );
+                    }
+                  }
+                  throw renameError;
+                }
+              } else {
+                await mgmt.savePrompt(id, prompt);
+              }
             }
             setEditor({ kind: "none" });
           }}
@@ -331,8 +366,9 @@ const PromptEditor: Component<{
       </Show>
 
       <div class="space-y-3">
-        <Field label="Display Name">
+        <Field label="Display Name" labelFor="prompt-display-name">
           <input
+            id="prompt-display-name"
             data-testid="field-display-name"
             value={displayName()}
             onInput={(e) => setDisplayName(e.currentTarget.value)}
@@ -341,8 +377,9 @@ const PromptEditor: Component<{
           />
         </Field>
 
-        <Field label="Instructions">
+        <Field label="Instructions" labelFor="prompt-instructions">
           <textarea
+            id="prompt-instructions"
             data-testid="field-instructions"
             value={instructions()}
             onInput={(e) => setInstructions(e.currentTarget.value)}
@@ -352,8 +389,9 @@ const PromptEditor: Component<{
           />
         </Field>
 
-        <Field label="Requested Skills (comma-separated)">
+        <Field label="Requested Skills (comma-separated)" labelFor="prompt-skills">
           <input
+            id="prompt-skills"
             data-testid="field-skills"
             value={skills()}
             onInput={(e) => setSkills(e.currentTarget.value)}
@@ -365,8 +403,9 @@ const PromptEditor: Component<{
           </div>
         </Field>
 
-        <Field label="Profile Assignment (optional)">
+        <Field label="Profile Assignment (optional)" labelFor="prompt-profile">
           <select
+            id="prompt-profile"
             data-testid="field-profile"
             value={profile()}
             onChange={(e) => setProfile(e.currentTarget.value)}
@@ -460,9 +499,9 @@ const DeleteDialog: Component<{
 
 // ── Helpers ──
 
-const Field: Component<{ label: string; children: JSX.Element }> = (props) => (
+const Field: Component<{ label: string; labelFor: string; children: JSX.Element }> = (props) => (
   <div>
-    <label class="mb-1 block text-xs font-medium text-text-secondary">{props.label}</label>
+    <label for={props.labelFor} class="mb-1 block text-xs font-medium text-text-secondary">{props.label}</label>
     {props.children}
   </div>
 );

--- a/src/components/agents/credential.test.tsx
+++ b/src/components/agents/credential.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, waitFor } from "@solidjs/testing-library";
+import { createSignal, type Component } from "solid-js";
+
+vi.mock("@lib/tauri/config-commands", () => ({
+  listProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  profileImpact: vi.fn(),
+  listPrompts: vi.fn(),
+  createPrompt: vi.fn(),
+  savePrompt: vi.fn(),
+  renamePrompt: vi.fn(),
+  deletePrompt: vi.fn(),
+  promptImpact: vi.fn(),
+  listCredentials: vi.fn(),
+  setApiKey: vi.fn(),
+  deleteCredential: vi.fn(),
+  restoreDefaultProfiles: vi.fn(),
+  getSharedConfigError: vi.fn().mockResolvedValue(null),
+  parseMutationError: vi.fn((e: unknown) => ({ kind: "unknown", message: typeof e === "string" ? e : String(e) })),
+}));
+
+import { listProfiles, listPrompts, listCredentials, setApiKey, deleteCredential } from "@lib/tauri/config-commands";
+import { ConfigManagementProvider, useConfigManagement, type ConfigManagementContextValue } from "@context/ConfigManagementContext";
+import { SettingsProvider } from "@context/SettingsContext";
+import { UIProvider } from "@context/UIContext";
+import { NotificationProvider } from "@context/NotificationContext";
+import { ProviderSettings } from "@components/settings/ProviderSettings";
+
+// Mock settings commands so SettingsProvider loads without real Tauri
+vi.mock("@lib/tauri/commands", () => ({
+  loadSettingsRows: vi.fn().mockResolvedValue([
+    { key: "providers", value: '[{"id":"openai","name":"OpenAI","enabled":true}]' },
+    { key: "default_model", value: "openai/gpt-4o" },
+  ]),
+  saveSettingRow: vi.fn().mockResolvedValue(undefined),
+  getProviderAuthStatus: vi.fn().mockResolvedValue({ provider: "openai", status: "notConfigured" }),
+  updateModelRegistry: vi.fn().mockResolvedValue([]),
+  startProviderOAuth: vi.fn(),
+  pollProviderOAuth: vi.fn(),
+  disconnectProviderOAuth: vi.fn(),
+}));
+
+const mockCredentialConfigured = {
+  providerSlug: "openai",
+  credentialMode: "apikey",
+  authStatus: "configuredApiKey",
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+const mockCredentialOAuth = {
+  providerSlug: "kimi-code",
+  credentialMode: "oauthbearer",
+  authStatus: "connectedOAuth",
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+function setupMocks(credentials: unknown[] = []) {
+  vi.mocked(listProfiles).mockResolvedValue([] as never);
+  vi.mocked(listPrompts).mockResolvedValue([] as never);
+  vi.mocked(listCredentials).mockResolvedValue(credentials as never);
+}
+
+function renderProviderSettings() {
+  return render(() => (
+    <SettingsProvider>
+      <UIProvider>
+        <NotificationProvider>
+          <ConfigManagementProvider>
+            <ProviderSettings />
+          </ConfigManagementProvider>
+        </NotificationProvider>
+      </UIProvider>
+    </SettingsProvider>
+  ));
+}
+
+describe("ProviderSettings credential management", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("renders 'Set' button when no API key is configured", async () => {
+    const { findByTestId } = renderProviderSettings();
+    const btn = await findByTestId("btn-set-apikey-openai");
+    expect(btn).toBeTruthy();
+  });
+
+  it("shows 'API key configured' when credential summary reports configuredApiKey", async () => {
+    setupMocks([mockCredentialConfigured]);
+    const { findByText } = renderProviderSettings();
+    expect(await findByText("API key configured")).toBeTruthy();
+  });
+
+  it("setApiKey routes through typed command and refreshes credentials", async () => {
+    vi.mocked(setApiKey).mockResolvedValue(mockCredentialConfigured as never);
+    setupMocks([]);
+
+    const [ctx, setCtx] = createSignal<ConfigManagementContextValue | null>(null);
+    const Probe: Component = () => {
+      setCtx(useConfigManagement());
+      return null;
+    };
+
+    render(() => (
+      <ConfigManagementProvider>
+        <Probe />
+      </ConfigManagementProvider>
+    ));
+
+    await waitFor(() => expect(vi.mocked(listCredentials)).toHaveBeenCalled());
+
+    await ctx()!.setApiKey("openai", "sk-test-123");
+
+    expect(vi.mocked(setApiKey)).toHaveBeenCalledWith("openai", "sk-test-123");
+    expect(vi.mocked(listCredentials).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("deleteCredential routes through typed command and refreshes credentials", async () => {
+    vi.mocked(deleteCredential).mockResolvedValue(undefined as never);
+    setupMocks([mockCredentialConfigured]);
+
+    const [ctx, setCtx] = createSignal<ConfigManagementContextValue | null>(null);
+    const Probe: Component = () => {
+      setCtx(useConfigManagement());
+      return null;
+    };
+
+    render(() => (
+      <ConfigManagementProvider>
+        <Probe />
+      </ConfigManagementProvider>
+    ));
+
+    await waitFor(() => expect(vi.mocked(listCredentials)).toHaveBeenCalled());
+
+    await ctx()!.deleteCredential("openai");
+
+    expect(vi.mocked(deleteCredential)).toHaveBeenCalledWith("openai");
+    expect(vi.mocked(listCredentials).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("calls deleteCredential when delete button is clicked", async () => {
+    vi.mocked(deleteCredential).mockResolvedValue(undefined as never);
+    setupMocks([mockCredentialConfigured]);
+    const { findByTestId } = renderProviderSettings();
+    const btn = await findByTestId("btn-delete-apikey-openai");
+
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(vi.mocked(deleteCredential)).toHaveBeenCalledWith("openai");
+    });
+  });
+
+  it("credential summaries include OAuth status without secrets", async () => {
+    setupMocks([mockCredentialConfigured, mockCredentialOAuth]);
+    renderProviderSettings();
+    await waitFor(() => {
+      expect(vi.mocked(listCredentials)).toHaveBeenCalled();
+    });
+    expect(mockCredentialConfigured).not.toHaveProperty("apiKey");
+    expect(mockCredentialOAuth).not.toHaveProperty("accessToken");
+    expect(mockCredentialOAuth.authStatus).toBe("connectedOAuth");
+  });
+
+  it("detects API key independently when both API key and OAuth credentials exist", async () => {
+    // Both credentials for the same provider — the frontend must find
+    // the API key even if the OAuth entry appears first.
+    const bothCreds = [
+      { ...mockCredentialOAuth, providerSlug: "openai" },
+      mockCredentialConfigured,
+    ];
+    setupMocks(bothCreds);
+    const { findByText } = renderProviderSettings();
+    expect(await findByText("API key configured")).toBeTruthy();
+  });
+});

--- a/src/components/agents/credential.test.tsx
+++ b/src/components/agents/credential.test.tsx
@@ -27,6 +27,7 @@ import { SettingsProvider } from "@context/SettingsContext";
 import { UIProvider } from "@context/UIContext";
 import { NotificationProvider } from "@context/NotificationContext";
 import { ProviderSettings } from "@components/settings/ProviderSettings";
+import { loadSettingsRows } from "@lib/tauri/commands";
 
 // Mock settings commands so SettingsProvider loads without real Tauri
 vi.mock("@lib/tauri/commands", () => ({
@@ -172,11 +173,17 @@ describe("ProviderSettings credential management", () => {
     // Both credentials for the same provider — the frontend must find
     // the API key even if the OAuth entry appears first.
     const bothCreds = [
-      { ...mockCredentialOAuth, providerSlug: "openai" },
-      mockCredentialConfigured,
+      mockCredentialOAuth,
+      { ...mockCredentialConfigured, providerSlug: "kimi-code" },
     ];
+    vi.mocked(loadSettingsRows).mockResolvedValue([
+      { key: "providers", value: '[{"id":"kimi-code","name":"Kimi for Coding","enabled":true}]' },
+      { key: "default_model", value: "kimi-code/kimi-for-coding" },
+    ]);
     setupMocks(bothCreds);
     const { findByText } = renderProviderSettings();
     expect(await findByText("API key configured")).toBeTruthy();
+    expect(await findByText(/API key takes precedence over OAuth/)).toBeTruthy();
+    expect(await findByText("OAuth credential stored")).toBeTruthy();
   });
 });

--- a/src/components/agents/navigation.test.tsx
+++ b/src/components/agents/navigation.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+import { type Component } from "solid-js";
+import { UIProvider, useUI } from "@context/UIContext";
+
+// Helper component to expose UI state in tests
+const StateProbe: Component = () => {
+  const ui = useUI();
+  return (
+    <div>
+      <span data-testid="current-view">{ui.currentView()}</span>
+      <span data-testid="agents-section">{ui.agentsSection()}</span>
+    </div>
+  );
+};
+
+// Minimal sidebar for navigation tests
+const TestSidebar: Component = () => {
+  const { currentView, setCurrentView } = useUI();
+  return (
+    <nav>
+      <button
+        data-testid="nav-chat"
+        onClick={() => setCurrentView("chat")}
+        class={currentView() === "chat" ? "active" : ""}
+      >
+        Chat
+      </button>
+      <button
+        data-testid="nav-agents"
+        onClick={() => setCurrentView("agents")}
+        class={currentView() === "agents" ? "active" : ""}
+      >
+        Agents
+      </button>
+      <button
+        data-testid="nav-settings"
+        onClick={() => setCurrentView("settings")}
+        class={currentView() === "settings" ? "active" : ""}
+      >
+        Settings
+      </button>
+    </nav>
+  );
+};
+
+describe("UIContext navigation", () => {
+  it("starts with chat view and profiles section", () => {
+    const { getByTestId } = render(() => (
+      <UIProvider>
+        <StateProbe />
+      </UIProvider>
+    ));
+    expect(getByTestId("current-view").textContent).toBe("chat");
+    expect(getByTestId("agents-section").textContent).toBe("profiles");
+  });
+
+  it("switches to agents view", () => {
+    const { getByTestId } = render(() => (
+      <UIProvider>
+        <TestSidebar />
+        <StateProbe />
+      </UIProvider>
+    ));
+    fireEvent.click(getByTestId("nav-agents"));
+    expect(getByTestId("current-view").textContent).toBe("agents");
+  });
+
+  it("switches between views", () => {
+    const { getByTestId } = render(() => (
+      <UIProvider>
+        <TestSidebar />
+        <StateProbe />
+      </UIProvider>
+    ));
+    fireEvent.click(getByTestId("nav-agents"));
+    expect(getByTestId("current-view").textContent).toBe("agents");
+    fireEvent.click(getByTestId("nav-settings"));
+    expect(getByTestId("current-view").textContent).toBe("settings");
+    fireEvent.click(getByTestId("nav-chat"));
+    expect(getByTestId("current-view").textContent).toBe("chat");
+  });
+});
+
+describe("ConfigManagementContext", () => {
+  it("reports zero profiles when list is empty", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "list_profiles") return Promise.resolve([]);
+      if (cmd === "list_prompts") return Promise.resolve([]);
+      if (cmd === "list_credentials") return Promise.resolve([]);
+      if (cmd === "get_shared_config_error") return Promise.resolve(null);
+      return Promise.resolve([]);
+    });
+
+    const { useConfigManagement, ConfigManagementProvider } = await import(
+      "@context/ConfigManagementContext"
+    );
+
+    const Probe: Component = () => {
+      const mgmt = useConfigManagement();
+      return (
+        <div>
+          <span data-testid="zero-profiles">{mgmt.zeroProfiles() ? "zero" : "has"}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(() => (
+      <ConfigManagementProvider>
+        <Probe />
+      </ConfigManagementProvider>
+    ));
+
+    await vi.waitFor(() => {
+      expect(getByTestId("zero-profiles").textContent).toBe("zero");
+    });
+  });
+
+  it("reports has profiles when at least one ready profile exists", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const mockProfile = {
+      status: "ready" as const,
+      entry: {
+        id: "explore",
+        profile: {
+          name: "Explore",
+          kind: "runtimeDefault" as const,
+          tools: { kind: "inherit" as const },
+          skills: { kind: "inherit" as const },
+          approval: "perTool" as const,
+        },
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "list_profiles") return Promise.resolve([mockProfile]);
+      if (cmd === "list_prompts") return Promise.resolve([]);
+      if (cmd === "list_credentials") return Promise.resolve([]);
+      if (cmd === "get_shared_config_error") return Promise.resolve(null);
+      return Promise.resolve([]);
+    });
+
+    const { useConfigManagement, ConfigManagementProvider } = await import(
+      "@context/ConfigManagementContext"
+    );
+
+    const Probe: Component = () => {
+      const mgmt = useConfigManagement();
+      return (
+        <div>
+          <span data-testid="zero-profiles">{mgmt.zeroProfiles() ? "zero" : "has"}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(() => (
+      <ConfigManagementProvider>
+        <Probe />
+      </ConfigManagementProvider>
+    ));
+
+    await vi.waitFor(() => {
+      expect(getByTestId("zero-profiles").textContent).toBe("has");
+    });
+  });
+
+  it("sets configInitError when shared config fails to initialize", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const initError = "Credential encryption is unavailable. Set AGENTIRON_CONFIG_ENCRYPTION_KEY.";
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "get_shared_config_error") return Promise.resolve(initError);
+      return Promise.resolve([]);
+    });
+
+    const { useConfigManagement, ConfigManagementProvider } = await import(
+      "@context/ConfigManagementContext"
+    );
+
+    const Probe: Component = () => {
+      const mgmt = useConfigManagement();
+      return (
+        <div>
+          <span data-testid="config-init-error">{mgmt.configInitError() ?? "none"}</span>
+          <span data-testid="zero-profiles">{mgmt.zeroProfiles() ? "zero" : "has"}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(() => (
+      <ConfigManagementProvider>
+        <Probe />
+      </ConfigManagementProvider>
+    ));
+
+    await vi.waitFor(() => {
+      expect(getByTestId("config-init-error").textContent).toContain("encryption");
+    });
+    // zeroProfiles returns false during config init error to avoid
+    // false recovery state.
+    expect(getByTestId("zero-profiles").textContent).toBe("has");
+  });
+
+  it("per-resource errors do not suppress zero-profile recovery", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "get_shared_config_error") return Promise.resolve(null);
+      if (cmd === "list_profiles") return Promise.resolve([]);
+      if (cmd === "list_prompts") return Promise.reject("Prompt load error");
+      if (cmd === "list_credentials") return Promise.reject("Credential load error");
+      return Promise.resolve([]);
+    });
+
+    const { useConfigManagement, ConfigManagementProvider } = await import(
+      "@context/ConfigManagementContext"
+    );
+
+    const Probe: Component = () => {
+      const mgmt = useConfigManagement();
+      return (
+        <div>
+          <span data-testid="zero-profiles">{mgmt.zeroProfiles() ? "zero" : "has"}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(() => (
+      <ConfigManagementProvider>
+        <Probe />
+      </ConfigManagementProvider>
+    ));
+
+    // Even though prompts and credentials failed, profile-based
+    // zero-profile detection should still work.
+    await vi.waitFor(() => {
+      expect(getByTestId("zero-profiles").textContent).toBe("zero");
+    });
+  });
+});

--- a/src/components/agents/navigation.test.tsx
+++ b/src/components/agents/navigation.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@solidjs/testing-library";
-import { type Component } from "solid-js";
+import { Show, type Component } from "solid-js";
 import { UIProvider, useUI } from "@context/UIContext";
+import { ConfigManagementProvider } from "@context/ConfigManagementContext";
+import { AgentsWorkspace } from "@components/agents/AgentsWorkspace";
+import { Sidebar } from "@components/layout/Sidebar";
 
 // Helper component to expose UI state in tests
 const StateProbe: Component = () => {
@@ -14,33 +17,16 @@ const StateProbe: Component = () => {
   );
 };
 
-// Minimal sidebar for navigation tests
-const TestSidebar: Component = () => {
-  const { currentView, setCurrentView } = useUI();
+const ProductionNavigation: Component = () => {
+  const { currentView } = useUI();
   return (
-    <nav>
-      <button
-        data-testid="nav-chat"
-        onClick={() => setCurrentView("chat")}
-        class={currentView() === "chat" ? "active" : ""}
-      >
-        Chat
-      </button>
-      <button
-        data-testid="nav-agents"
-        onClick={() => setCurrentView("agents")}
-        class={currentView() === "agents" ? "active" : ""}
-      >
-        Agents
-      </button>
-      <button
-        data-testid="nav-settings"
-        onClick={() => setCurrentView("settings")}
-        class={currentView() === "settings" ? "active" : ""}
-      >
-        Settings
-      </button>
-    </nav>
+    <div>
+      <Sidebar />
+      <Show when={currentView() === "agents"}>
+        <AgentsWorkspace />
+      </Show>
+      <StateProbe />
+    </div>
   );
 };
 
@@ -55,29 +41,52 @@ describe("UIContext navigation", () => {
     expect(getByTestId("agents-section").textContent).toBe("profiles");
   });
 
-  it("switches to agents view", () => {
-    const { getByTestId } = render(() => (
-      <UIProvider>
-        <TestSidebar />
-        <StateProbe />
-      </UIProvider>
+  it("opens the production agents workspace from the sidebar", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "get_shared_config_error") return Promise.resolve(null);
+      if (cmd === "list_profiles") return Promise.resolve([{
+        status: "ready",
+        entry: {
+          id: "explore",
+          profile: {
+            name: "Explore",
+            kind: "runtimeDefault",
+            tools: { kind: "inherit" },
+            skills: { kind: "inherit" },
+            approval: "perTool",
+          },
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+        },
+      }]);
+      return Promise.resolve([]);
+    });
+
+    const { getByTestId, getByRole, findByTestId } = render(() => (
+      <ConfigManagementProvider>
+        <UIProvider>
+          <ProductionNavigation />
+        </UIProvider>
+      </ConfigManagementProvider>
     ));
-    fireEvent.click(getByTestId("nav-agents"));
+    fireEvent.click(getByRole("button", { name: "Agents" }));
     expect(getByTestId("current-view").textContent).toBe("agents");
+    expect(await findByTestId("btn-new-profile")).toBeTruthy();
   });
 
   it("switches between views", () => {
-    const { getByTestId } = render(() => (
+    const { getByTestId, getByRole } = render(() => (
       <UIProvider>
-        <TestSidebar />
+        <Sidebar />
         <StateProbe />
       </UIProvider>
     ));
-    fireEvent.click(getByTestId("nav-agents"));
+    fireEvent.click(getByRole("button", { name: "Agents" }));
     expect(getByTestId("current-view").textContent).toBe("agents");
-    fireEvent.click(getByTestId("nav-settings"));
+    fireEvent.click(getByRole("button", { name: "Settings" }));
     expect(getByTestId("current-view").textContent).toBe("settings");
-    fireEvent.click(getByTestId("nav-chat"));
+    fireEvent.click(getByRole("button", { name: "Chat" }));
     expect(getByTestId("current-view").textContent).toBe("chat");
   });
 });

--- a/src/components/agents/profile-list.test.tsx
+++ b/src/components/agents/profile-list.test.tsx
@@ -187,6 +187,31 @@ describe("ProfileList", () => {
     });
   });
 
+  it("submits a profile deletion only once while it is pending", async () => {
+    vi.mocked(profileImpact).mockResolvedValue({
+      target: { kind: "profile", id: "explore" },
+      links: [],
+      diagnostics: [],
+    } as never);
+    let resolveDelete!: () => void;
+    vi.mocked(deleteProfile).mockReturnValue(new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    }) as never);
+
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+    fireEvent.click(getByTestId("btn-delete-explore"));
+    await findByTestId("delete-dialog");
+
+    const confirmBtn = await findByTestId("btn-confirm-delete");
+    fireEvent.click(confirmBtn);
+    fireEvent.click(confirmBtn);
+
+    expect(vi.mocked(deleteProfile)).toHaveBeenCalledTimes(1);
+    expect(confirmBtn).toHaveProperty("disabled", true);
+    resolveDelete();
+  });
+
   it("shows error when deleting last valid profile", async () => {
     vi.mocked(profileImpact).mockResolvedValue({
       target: { kind: "profile", id: "explore" },

--- a/src/components/agents/profile-list.test.tsx
+++ b/src/components/agents/profile-list.test.tsx
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, waitFor } from "@solidjs/testing-library";
+
+vi.mock("@lib/tauri/config-commands", () => ({
+  listProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  profileImpact: vi.fn(),
+  listPrompts: vi.fn(),
+  createPrompt: vi.fn(),
+  savePrompt: vi.fn(),
+  renamePrompt: vi.fn(),
+  deletePrompt: vi.fn(),
+  promptImpact: vi.fn(),
+  listCredentials: vi.fn(),
+  setApiKey: vi.fn(),
+  deleteCredential: vi.fn(),
+  restoreDefaultProfiles: vi.fn(),
+  getSharedConfigError: vi.fn().mockResolvedValue(null),
+  parseMutationError: vi.fn((e: unknown) => ({ kind: "unknown", message: typeof e === "string" ? e : String(e) })),
+  formatDependencyEntity: vi.fn((entity: { kind: string; id?: string; slug?: string }) =>
+    `${entity.kind}: ${entity.id ?? entity.slug}`
+  ),
+}));
+
+import { listProfiles, saveProfile, deleteProfile, profileImpact, listPrompts, listCredentials } from "@lib/tauri/config-commands";
+import { ConfigManagementProvider } from "@context/ConfigManagementContext";
+import { ProfileList } from "@components/agents/ProfileList";
+
+const mockReadyProfile = {
+  status: "ready" as const,
+  entry: {
+    id: "explore",
+    profile: {
+      name: "Explore",
+      kind: "runtimeDefault" as const,
+      tools: { kind: "inherit" as const },
+      skills: { kind: "inherit" as const },
+      approval: "perTool" as const,
+    },
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+};
+
+const mockNeedsAttention = {
+  status: "needsAttention" as const,
+  id: "bad-profile",
+  diagnostics: [{ category: "invalidPayload", message: "Corrupt data" }],
+};
+
+function setupProfileMocks(profiles: unknown[] = [mockReadyProfile]) {
+  vi.mocked(listProfiles).mockResolvedValue(profiles as never);
+  vi.mocked(listPrompts).mockResolvedValue([] as never);
+  vi.mocked(listCredentials).mockResolvedValue([] as never);
+}
+
+function renderProfileList() {
+  return render(() => (
+    <ConfigManagementProvider>
+      <ProfileList />
+    </ConfigManagementProvider>
+  ));
+}
+
+describe("ProfileList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupProfileMocks();
+  });
+
+  it("displays ready profiles", async () => {
+    const { getByText, findByTestId } = renderProfileList();
+    await waitFor(() => {
+      expect(getByText("Explore")).toBeTruthy();
+    });
+    expect(findByTestId("profile-row-explore")).toBeTruthy();
+  });
+
+  it("displays needs-attention profiles with diagnostics", async () => {
+    setupProfileMocks([mockReadyProfile, mockNeedsAttention]);
+    const { getByText } = renderProfileList();
+    await waitFor(() => {
+      expect(getByText("bad-profile")).toBeTruthy();
+      expect(getByText("Needs attention")).toBeTruthy();
+    });
+  });
+
+  it("opens new profile editor on button click", async () => {
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-profile"));
+    expect(await findByTestId("profile-editor")).toBeTruthy();
+    expect(getByTestId("field-id")).toBeTruthy();
+  });
+
+  it("opens edit profile editor with existing values", async () => {
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-explore"));
+    const editor = await findByTestId("profile-editor");
+    expect(editor).toBeTruthy();
+    expect((getByTestId("field-name") as HTMLInputElement).value).toBe("Explore");
+  });
+
+  it("cancels editor without saving", async () => {
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-profile"));
+    await findByTestId("profile-editor");
+
+    fireEvent.click(getByTestId("btn-cancel"));
+    await waitFor(() => {
+      expect(getByTestId("btn-new-profile")).toBeTruthy();
+    });
+  });
+
+  it("saves new profile through command", async () => {
+    vi.mocked(saveProfile).mockResolvedValue(undefined as never);
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-profile"));
+    await findByTestId("profile-editor");
+
+    fireEvent.input(getByTestId("field-id"), { target: { value: "test-profile" } });
+    fireEvent.input(getByTestId("field-name"), { target: { value: "Test" } });
+    fireEvent.click(getByTestId("btn-save"));
+
+    await waitFor(() => {
+      expect(vi.mocked(saveProfile)).toHaveBeenCalledWith("test-profile", expect.objectContaining({
+        name: "Test",
+      }));
+    });
+  });
+
+  it("shows delete dialog with dependent prompts", async () => {
+    vi.mocked(profileImpact).mockResolvedValue({
+      target: { kind: "profile", id: "explore" },
+      links: [{
+        entity: { kind: "prompt", id: "my-prompt" },
+        direction: "dependent",
+        proximity: "direct",
+        path: [
+          { kind: "profile", id: "explore" },
+          { kind: "prompt", id: "my-prompt" },
+        ],
+      }],
+      diagnostics: [],
+    } as never);
+    vi.mocked(deleteProfile).mockResolvedValue(undefined as never);
+
+    const { getByTestId, getByText, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-delete-explore"));
+    const dialog = await findByTestId("delete-dialog");
+    expect(dialog).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText(/my-prompt/)).toBeTruthy();
+    });
+    // Delete button should be hidden when there are dependents
+    expect(() => getByTestId("btn-confirm-delete")).toThrow();
+  });
+
+  it("allows deletion when no dependents", async () => {
+    vi.mocked(profileImpact).mockResolvedValue({
+      target: { kind: "profile", id: "explore" },
+      links: [],
+      diagnostics: [],
+    } as never);
+    vi.mocked(deleteProfile).mockResolvedValue(undefined as never);
+
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-delete-explore"));
+    await findByTestId("delete-dialog");
+
+    const confirmBtn = await findByTestId("btn-confirm-delete");
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(vi.mocked(deleteProfile)).toHaveBeenCalledWith("explore");
+    });
+  });
+
+  it("shows error when deleting last valid profile", async () => {
+    vi.mocked(profileImpact).mockResolvedValue({
+      target: { kind: "profile", id: "explore" },
+      links: [],
+      diagnostics: [],
+    } as never);
+    vi.mocked(deleteProfile).mockRejectedValue(
+      "Cannot delete the last valid agent profile." as never
+    );
+
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-delete-explore"));
+    await findByTestId("delete-dialog");
+
+    const confirmBtn = await findByTestId("btn-confirm-delete");
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(getByTestId("delete-error").textContent).toContain("last valid");
+    });
+  });
+
+  it("preserves unknown tool identifiers with suggestions", async () => {
+    const profileWithUnknown = {
+      status: "ready" as const,
+      entry: {
+        id: "custom",
+        profile: {
+          name: "Custom",
+          kind: "runtimeDefault" as const,
+          tools: { kind: "allow" as const, names: ["unknown-tool", "read"] },
+          skills: { kind: "inherit" as const },
+          approval: "perTool" as const,
+        },
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+    };
+    setupProfileMocks([profileWithUnknown]);
+
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-custom")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-custom"));
+    const editor = await findByTestId("profile-editor");
+    expect(editor).toBeTruthy();
+    // Tool names should include the unknown tool
+    expect((getByTestId("field-tool-names") as HTMLInputElement).value).toContain("unknown-tool");
+  });
+
+  it("rejects creating a profile with an existing ID", async () => {
+    vi.mocked(saveProfile).mockResolvedValue(undefined as never);
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-explore")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-profile"));
+    await findByTestId("profile-editor");
+
+    // Use an ID that already exists
+    fireEvent.input(getByTestId("field-id"), { target: { value: "explore" } });
+    fireEvent.input(getByTestId("field-name"), { target: { value: "Duplicate" } });
+    fireEvent.click(getByTestId("btn-save"));
+
+    await waitFor(() => {
+      expect(getByTestId("form-error").textContent).toContain("already exists");
+    });
+    expect(vi.mocked(saveProfile)).not.toHaveBeenCalled();
+  });
+
+  it("allows editing needs-attention profiles with decoded payload", async () => {
+    const needsAttentionWithDecoded = {
+      status: "needsAttention" as const,
+      id: "weird-profile",
+      decoded: {
+        name: "Weird",
+        kind: "runtimeDefault" as const,
+        tools: { kind: "inherit" as const },
+        skills: { kind: "inherit" as const },
+        approval: "perTool" as const,
+      },
+      diagnostics: [{ category: "unavailableSkill", message: "Skill 'xyz' not found" }],
+    };
+    setupProfileMocks([mockReadyProfile, needsAttentionWithDecoded]);
+
+    const { getByTestId, findByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-weird-profile")).toBeTruthy());
+
+    // Edit button should be visible for needs-attention with decoded
+    fireEvent.click(getByTestId("btn-edit-weird-profile"));
+    const editor = await findByTestId("profile-editor");
+    expect(editor).toBeTruthy();
+    expect((getByTestId("field-name") as HTMLInputElement).value).toBe("Weird");
+  });
+
+  it("hides edit button for needs-attention profiles without decoded payload", async () => {
+    setupProfileMocks([mockReadyProfile, mockNeedsAttention]);
+    const { getByTestId } = renderProfileList();
+    await waitFor(() => expect(getByTestId("profile-row-bad-profile")).toBeTruthy());
+
+    // No edit button should exist for needs-attention without decoded
+    expect(() => getByTestId("btn-edit-bad-profile")).toThrow();
+  });
+});

--- a/src/components/agents/prompt-list.test.tsx
+++ b/src/components/agents/prompt-list.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@lib/tauri/config-commands", () => ({
   ),
 }));
 
-import { listProfiles, listPrompts, listCredentials, createPrompt, deletePrompt, promptImpact } from "@lib/tauri/config-commands";
+import { listProfiles, listPrompts, listCredentials, createPrompt, savePrompt, renamePrompt, deletePrompt, promptImpact } from "@lib/tauri/config-commands";
 import { ConfigManagementProvider } from "@context/ConfigManagementContext";
 import { PromptList } from "@components/agents/PromptList";
 
@@ -152,6 +152,64 @@ describe("PromptList", () => {
         displayName: "My Task",
         instructions: "Do the thing",
       }));
+    });
+  });
+
+  it("renames an existing prompt through the rename command", async () => {
+    vi.mocked(renamePrompt).mockResolvedValue(undefined as never);
+    vi.mocked(savePrompt).mockResolvedValue(undefined as never);
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-prompt-prompt-abc"));
+    await findByTestId("prompt-editor");
+    fireEvent.input(getByTestId("field-display-name"), { target: { value: "Review Email" } });
+    fireEvent.click(getByTestId("btn-save-prompt"));
+
+    await waitFor(() => {
+      expect(vi.mocked(renamePrompt)).toHaveBeenCalledWith("prompt-abc", "Review Email");
+      expect(vi.mocked(savePrompt)).not.toHaveBeenCalled();
+    });
+  });
+
+  it("saves non-identity edits before renaming a prompt", async () => {
+    vi.mocked(renamePrompt).mockResolvedValue(undefined as never);
+    vi.mocked(savePrompt).mockResolvedValue(undefined as never);
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-prompt-prompt-abc"));
+    await findByTestId("prompt-editor");
+    fireEvent.input(getByTestId("field-display-name"), { target: { value: "Review Email" } });
+    fireEvent.input(getByTestId("field-instructions"), { target: { value: "Review unread email." } });
+    fireEvent.click(getByTestId("btn-save-prompt"));
+
+    await waitFor(() => {
+      expect(vi.mocked(savePrompt)).toHaveBeenCalledWith("prompt-abc", expect.objectContaining({
+        displayName: "Check Email",
+        normalizedName: "check-email",
+        instructions: "Review unread email.",
+      }));
+      expect(vi.mocked(renamePrompt)).toHaveBeenCalledWith("prompt-abc", "Review Email");
+    });
+  });
+
+  it("rolls back non-identity edits when renaming fails", async () => {
+    vi.mocked(renamePrompt).mockRejectedValue("Name already exists" as never);
+    vi.mocked(savePrompt).mockResolvedValue(undefined as never);
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-prompt-prompt-abc"));
+    await findByTestId("prompt-editor");
+    fireEvent.input(getByTestId("field-display-name"), { target: { value: "Review Email" } });
+    fireEvent.input(getByTestId("field-instructions"), { target: { value: "Review unread email." } });
+    fireEvent.click(getByTestId("btn-save-prompt"));
+
+    await waitFor(() => {
+      expect(vi.mocked(savePrompt)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(savePrompt)).toHaveBeenLastCalledWith("prompt-abc", mockReadyPrompt.entry.prompt);
+      expect(getByTestId("form-error").textContent).toContain("Name already exists");
     });
   });
 

--- a/src/components/agents/prompt-list.test.tsx
+++ b/src/components/agents/prompt-list.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, waitFor } from "@solidjs/testing-library";
+
+vi.mock("@lib/tauri/config-commands", () => ({
+  listProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  profileImpact: vi.fn(),
+  listPrompts: vi.fn(),
+  createPrompt: vi.fn(),
+  savePrompt: vi.fn(),
+  renamePrompt: vi.fn(),
+  deletePrompt: vi.fn(),
+  promptImpact: vi.fn(),
+  listCredentials: vi.fn(),
+  setApiKey: vi.fn(),
+  deleteCredential: vi.fn(),
+  restoreDefaultProfiles: vi.fn(),
+  getSharedConfigError: vi.fn().mockResolvedValue(null),
+  parseMutationError: vi.fn((e: unknown) => ({ kind: "unknown", message: typeof e === "string" ? e : String(e) })),
+  formatDependencyEntity: vi.fn((entity: { kind: string; id?: string; slug?: string }) =>
+    `${entity.kind}: ${entity.id ?? entity.slug}`
+  ),
+}));
+
+import { listProfiles, listPrompts, listCredentials, createPrompt, deletePrompt, promptImpact } from "@lib/tauri/config-commands";
+import { ConfigManagementProvider } from "@context/ConfigManagementContext";
+import { PromptList } from "@components/agents/PromptList";
+
+const mockReadyPrompt = {
+  status: "ready" as const,
+  entry: {
+    id: "prompt-abc",
+    prompt: {
+      displayName: "Check Email",
+      normalizedName: "check-email",
+      instructions: "Check and summarize email.",
+      skills: ["email-reader"],
+      profile: "explore",
+    },
+    identityState: "ready",
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+};
+
+const mockReadyProfile = {
+  status: "ready" as const,
+  entry: {
+    id: "explore",
+    profile: {
+      name: "Explore",
+      kind: "runtimeDefault" as const,
+      tools: { kind: "inherit" as const },
+      skills: { kind: "inherit" as const },
+      approval: "perTool" as const,
+    },
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+};
+
+function setupMocks(prompts: unknown[] = [mockReadyPrompt]) {
+  vi.mocked(listProfiles).mockResolvedValue([mockReadyProfile] as never);
+  vi.mocked(listPrompts).mockResolvedValue(prompts as never);
+  vi.mocked(listCredentials).mockResolvedValue([] as never);
+}
+
+function renderPromptList() {
+  return render(() => (
+    <ConfigManagementProvider>
+      <PromptList />
+    </ConfigManagementProvider>
+  ));
+}
+
+describe("PromptList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("displays ready prompts with profile assignment", async () => {
+    const { getByText } = renderPromptList();
+    await waitFor(() => {
+      expect(getByText("Check Email")).toBeTruthy();
+      expect(getByText("-> Explore")).toBeTruthy();
+    });
+  });
+
+  it("displays needs-attention prompts with diagnostics", async () => {
+    const needsAttention = {
+      status: "needsAttention" as const,
+      id: "bad-prompt",
+      diagnostics: [{ category: "invalidPayload", message: "Decode failed" }],
+    };
+    setupMocks([mockReadyPrompt, needsAttention]);
+    const { getByText } = renderPromptList();
+    await waitFor(() => {
+      expect(getByText("bad-prompt")).toBeTruthy();
+      expect(getByText("Needs attention")).toBeTruthy();
+    });
+  });
+
+  it("opens new prompt editor on button click", async () => {
+    const { getByTestId, findByTestId, getByText } = renderPromptList();
+    await waitFor(() => expect(getByText("Check Email")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-prompt"));
+    expect(await findByTestId("prompt-editor")).toBeTruthy();
+    expect(getByTestId("field-display-name")).toBeTruthy();
+  });
+
+  it("opens edit prompt editor with existing values", async () => {
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-prompt-prompt-abc"));
+    const editor = await findByTestId("prompt-editor");
+    expect(editor).toBeTruthy();
+    expect((getByTestId("field-display-name") as HTMLInputElement).value).toBe("Check Email");
+    expect((getByTestId("field-instructions") as HTMLTextAreaElement).value).toContain("Check and summarize");
+  });
+
+  it("cancels editor without saving", async () => {
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-prompt"));
+    await findByTestId("prompt-editor");
+
+    fireEvent.click(getByTestId("btn-cancel-prompt"));
+    await waitFor(() => {
+      expect(getByTestId("btn-new-prompt")).toBeTruthy();
+    });
+  });
+
+  it("creates new prompt through create command", async () => {
+    vi.mocked(createPrompt).mockResolvedValue(["prompt-new", mockReadyPrompt.entry.prompt] as never);
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-new-prompt"));
+    await findByTestId("prompt-editor");
+
+    fireEvent.input(getByTestId("field-display-name"), { target: { value: "My Task" } });
+    fireEvent.input(getByTestId("field-instructions"), { target: { value: "Do the thing" } });
+    fireEvent.click(getByTestId("btn-save-prompt"));
+
+    await waitFor(() => {
+      expect(vi.mocked(createPrompt)).toHaveBeenCalledWith(expect.objectContaining({
+        displayName: "My Task",
+        instructions: "Do the thing",
+      }));
+    });
+  });
+
+  it("preserves unknown skill identifiers", async () => {
+    const promptWithUnknown = {
+      status: "ready" as const,
+      entry: {
+        id: "prompt-xyz",
+        prompt: {
+          displayName: "Custom Task",
+          normalizedName: "custom-task",
+          instructions: "Do custom thing",
+          skills: ["unknown-skill", "known"],
+        },
+        identityState: "ready",
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+    };
+    setupMocks([promptWithUnknown]);
+
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-xyz")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-edit-prompt-prompt-xyz"));
+    const editor = await findByTestId("prompt-editor");
+    expect(editor).toBeTruthy();
+    expect((getByTestId("field-skills") as HTMLInputElement).value).toContain("unknown-skill");
+  });
+
+  it("blocks deletion when there are dependents", async () => {
+    vi.mocked(promptImpact).mockResolvedValue({
+      target: { kind: "prompt", id: "prompt-abc" },
+      links: [{
+        entity: { kind: "automationTask", id: "task-1" },
+        direction: "dependent",
+        proximity: "direct",
+        path: [
+          { kind: "prompt", id: "prompt-abc" },
+          { kind: "automationTask", id: "task-1" },
+        ],
+      }],
+      diagnostics: [],
+    } as never);
+
+    const { getByTestId, findByTestId, getByText } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-delete-prompt-prompt-abc"));
+    await findByTestId("prompt-delete-dialog");
+
+    await waitFor(() => {
+      expect(getByText(/task-1/)).toBeTruthy();
+    });
+    expect(() => getByTestId("btn-confirm-delete-prompt")).toThrow();
+  });
+
+  it("deletes when no dependents", async () => {
+    vi.mocked(promptImpact).mockResolvedValue({
+      target: { kind: "prompt", id: "prompt-abc" },
+      links: [],
+      diagnostics: [],
+    } as never);
+    vi.mocked(deletePrompt).mockResolvedValue(undefined as never);
+
+    const { getByTestId, findByTestId } = renderPromptList();
+    await waitFor(() => expect(getByTestId("prompt-row-prompt-abc")).toBeTruthy());
+
+    fireEvent.click(getByTestId("btn-delete-prompt-prompt-abc"));
+    await findByTestId("prompt-delete-dialog");
+
+    const confirmBtn = await findByTestId("btn-confirm-delete-prompt");
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(vi.mocked(deletePrompt)).toHaveBeenCalledWith("prompt-abc");
+    });
+  });
+});

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "./Sidebar";
 import { TabBar } from "./TabBar";
 import { ChatArea } from "@components/chat/ChatArea";
 import { SettingsPanel } from "@components/settings/SettingsPanel";
+import { AgentsWorkspace } from "@components/agents/AgentsWorkspace";
 import { useAgent } from "@context/AgentContext";
 import { useSettings } from "@context/SettingsContext";
 import { useUI } from "@context/UIContext";
@@ -65,16 +66,20 @@ export const AppShell: Component = () => {
               <Show
                 when={currentView() === "settings"}
                 fallback={
-                  <Show
-                    when={defaultProviderConfigured()}
-                    fallback={<DefaultProviderPrompt />}
-                  >
+                  <Show when={currentView() === "agents"} fallback={
                     <Show
-                      when={agentState.activeTabId}
-                      fallback={<NoActiveAgentFallback starting={initialAgentCreating()} />}
+                      when={defaultProviderConfigured()}
+                      fallback={<DefaultProviderPrompt />}
                     >
-                      <ChatArea />
+                      <Show
+                        when={agentState.activeTabId}
+                        fallback={<NoActiveAgentFallback starting={initialAgentCreating()} />}
+                      >
+                        <ChatArea />
+                      </Show>
                     </Show>
+                  }>
+                    <AgentsWorkspace />
                   </Show>
                 }
               >

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,6 +30,8 @@ export const Sidebar: Component = () => {
         <SidebarItem
           label="Agents"
           icon={<TbOutlineRobot size={16} />}
+          active={currentView() === "agents"}
+          onClick={() => setCurrentView("agents")}
         />
         <SidebarItem
           label="Tasks"

--- a/src/components/settings/ProviderSettings.tsx
+++ b/src/components/settings/ProviderSettings.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createSignal, type Component } from "solid-js";
+import { For, Show, createSignal, onCleanup, type Component } from "solid-js";
 import {
   TbOutlineStar,
   TbFillStar,
@@ -12,6 +12,7 @@ import {
   TbOutlineUnlink,
 } from "solid-icons/tb";
 import { useSettings } from "@context/SettingsContext";
+import { useConfigManagement, MutationError } from "@context/ConfigManagementContext";
 import { useNotification } from "@context/NotificationContext";
 import { DEFAULT_PROVIDERS, PROVIDER_METADATA, formatTokenCount, parseModelSlug, makeModelSlug } from "@lib/models";
 import { startProviderOAuth, pollProviderOAuth, disconnectProviderOAuth } from "@lib/tauri/commands";
@@ -249,10 +250,15 @@ const ProviderCard: Component<{
   onUpdate: (patch: Partial<ProviderConfig>) => void;
   onRemove: () => void;
 }> = (props) => {
-  const [showKey, setShowKey] = createSignal(false);
   const { authStatuses, refreshAuthStatus } = useSettings();
+  const mgmt = useConfigManagement();
   const meta = () => PROVIDER_METADATA.find((m) => m.id === props.provider.id);
   const auth = () => authStatuses()[props.provider.id];
+
+  const hasApiKey = () => mgmt.credentials().some(
+    (c) => c.providerSlug === props.provider.id && c.authStatus === "configuredApiKey"
+  );
+  const hasOAuth = () => auth()?.status === "connectedOAuth";
 
   const [connecting, setConnecting] = createSignal(false);
   const [deviceCodeData, setDeviceCodeData] = createSignal<{
@@ -264,13 +270,55 @@ const ProviderCard: Component<{
   } | null>(null);
   const [pollAttempts, setPollAttempts] = createSignal(0);
   const [connectError, setConnectError] = createSignal("");
-  const apiKey = () => props.provider.apiKey ?? "";
+  const [newApiKey, setNewApiKey] = createSignal("");
+  const [apiKeyError, setApiKeyError] = createSignal("");
+
+  // OAuth poll cancellation state.
+  const pollState: { timerId: ReturnType<typeof setTimeout> | null; cancelled: boolean } = {
+    timerId: null,
+    cancelled: false,
+  };
+
+  const cancelOAuthPoll = () => {
+    pollState.cancelled = true;
+    if (pollState.timerId !== null) {
+      clearTimeout(pollState.timerId);
+      pollState.timerId = null;
+    }
+  };
+
+  onCleanup(() => {
+    cancelOAuthPoll();
+  });
 
   const effectiveAuth = () => {
-    if (apiKey().trim().length > 0) return "api_key";
-    const status = auth()?.status;
-    if (status === "connectedOAuth" || status === "configuredApiKey") return "oauth";
+    if (hasApiKey()) return "api_key";
+    if (hasOAuth()) return "oauth";
     return "none";
+  };
+
+  const handleSetApiKey = async () => {
+    const key = newApiKey().trim();
+    if (!key) return;
+    setApiKeyError("");
+    try {
+      await mgmt.setApiKey(props.provider.id, key);
+      setNewApiKey("");
+      await refreshAuthStatus(props.provider.id);
+    } catch (e) {
+      setApiKeyError(e instanceof MutationError ? e.dto.message : String(e));
+      setNewApiKey("");
+    }
+  };
+
+  const handleDeleteApiKey = async () => {
+    setApiKeyError("");
+    try {
+      await mgmt.deleteCredential(props.provider.id);
+      await refreshAuthStatus(props.provider.id);
+    } catch (e) {
+      setApiKeyError(e instanceof MutationError ? e.dto.message : String(e));
+    }
   };
 
   const authorizationLinkIncludesCode = () => {
@@ -279,10 +327,12 @@ const ProviderCard: Component<{
   };
 
   const handleConnect = async () => {
+    pollState.cancelled = false;
     setConnecting(true);
     setConnectError("");
     try {
       const start = await startProviderOAuth(props.provider.id);
+      if (pollState.cancelled) return;
       setDeviceCodeData({
         deviceCode: start.deviceCode,
         verificationUri: start.verificationUri,
@@ -292,10 +342,10 @@ const ProviderCard: Component<{
       });
       setPollAttempts(0);
 
-      // Start polling
       let attempts = 0;
       const maxAttempts = Math.ceil(start.expiresInSecs / start.intervalSecs);
       const poll = async () => {
+        if (pollState.cancelled) return;
         if (attempts >= maxAttempts) {
           setConnectError("Device code expired. Please try again.");
           setDeviceCodeData(null);
@@ -307,14 +357,17 @@ const ProviderCard: Component<{
         setPollAttempts(attempts);
         try {
           await pollProviderOAuth(props.provider.id, start.deviceCode);
+          if (pollState.cancelled) return;
           await refreshAuthStatus(props.provider.id);
+          await mgmt.refreshCredentials();
           setDeviceCodeData(null);
           setPollAttempts(0);
           setConnecting(false);
         } catch (e) {
+          if (pollState.cancelled) return;
           const errMsg = String(e);
           if (errMsg.includes("authorization pending") || errMsg.includes("polling too fast")) {
-            setTimeout(poll, start.intervalSecs * 1000);
+            pollState.timerId = setTimeout(poll, start.intervalSecs * 1000);
           } else {
             setConnectError(errMsg);
             setDeviceCodeData(null);
@@ -323,17 +376,20 @@ const ProviderCard: Component<{
           }
         }
       };
-      setTimeout(poll, start.intervalSecs * 1000);
+      pollState.timerId = setTimeout(poll, start.intervalSecs * 1000);
     } catch (e) {
-      setConnectError(String(e));
-      setPollAttempts(0);
-      setConnecting(false);
+      if (!pollState.cancelled) {
+        setConnectError(String(e));
+        setPollAttempts(0);
+        setConnecting(false);
+      }
     }
   };
 
   const handleDisconnect = async () => {
     await disconnectProviderOAuth(props.provider.id);
     await refreshAuthStatus(props.provider.id);
+    await mgmt.refreshCredentials();
   };
 
   return (
@@ -410,22 +466,52 @@ const ProviderCard: Component<{
         </div>
       </Show>
 
-      {/* API Key input (shown for api_key and dual providers) */}
+      {/* API Key management (write-only, secret-safe) */}
       <Show when={meta()?.auth !== "oauth"}>
-        <div class="relative">
-          <input
-            type={showKey() ? "text" : "password"}
-            placeholder="API key..."
-            value={apiKey()}
-            onInput={(e) => props.onUpdate({ apiKey: e.currentTarget.value })}
-            class="w-full rounded-lg border border-border-default bg-bg-tertiary px-3 py-2 pr-16 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent focus:outline-none font-mono"
-          />
-          <button
-            onClick={() => setShowKey(!showKey())}
-            class="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-text-tertiary hover:text-text-primary transition-colors"
-          >
-            {showKey() ? "Hide" : "Show"}
-          </button>
+        <div class="space-y-2">
+          <Show when={hasApiKey()}>
+            <div class="flex items-center justify-between rounded-md border border-success/20 bg-success/5 px-3 py-2">
+              <span class="text-xs text-success" data-testid={`apikey-configured-${props.provider.id}`}>
+                API key configured
+              </span>
+              <div class="flex items-center gap-1">
+                <button
+                  onClick={handleDeleteApiKey}
+                  data-testid={`btn-delete-apikey-${props.provider.id}`}
+                  class="rounded p-1 text-text-tertiary hover:text-error hover:bg-error/10"
+                  title="Delete API key"
+                >
+                  <TbOutlineTrash size={14} />
+                </button>
+              </div>
+            </div>
+            <Show when={hasOAuth()}>
+              <p class="text-xs text-text-tertiary">
+                API key takes precedence over OAuth. Delete the API key to use OAuth.
+              </p>
+            </Show>
+          </Show>
+          <div class="flex gap-2">
+            <input
+              type="password"
+              placeholder={hasApiKey() ? "Enter new key to replace..." : "API key..."}
+              value={newApiKey()}
+              onInput={(e) => setNewApiKey(e.currentTarget.value)}
+              data-testid={`apikey-input-${props.provider.id}`}
+              class="flex-1 rounded-lg border border-border-default bg-bg-tertiary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent focus:outline-none font-mono"
+            />
+            <button
+              onClick={handleSetApiKey}
+              disabled={!newApiKey().trim()}
+              data-testid={`btn-set-apikey-${props.provider.id}`}
+              class="px-3 py-2 rounded-lg text-xs bg-accent text-void hover:bg-accent-hover transition-colors disabled:opacity-50"
+            >
+              {hasApiKey() ? "Replace" : "Set"}
+            </button>
+          </div>
+          <Show when={apiKeyError()}>
+            <p class="text-xs text-error" data-testid={`apikey-error-${props.provider.id}`}>{apiKeyError()}</p>
+          </Show>
         </div>
       </Show>
 
@@ -496,6 +582,7 @@ const ProviderCard: Component<{
               </p>
               <button
                 onClick={() => {
+                  cancelOAuthPoll();
                   setDeviceCodeData(null);
                   setPollAttempts(0);
                   setConnecting(false);

--- a/src/components/settings/ProviderSettings.tsx
+++ b/src/components/settings/ProviderSettings.tsx
@@ -258,7 +258,9 @@ const ProviderCard: Component<{
   const hasApiKey = () => mgmt.credentials().some(
     (c) => c.providerSlug === props.provider.id && c.authStatus === "configuredApiKey"
   );
-  const hasOAuth = () => auth()?.status === "connectedOAuth";
+  const hasOAuth = () => auth()?.status === "connectedOAuth" || mgmt.credentials().some(
+    (c) => c.providerSlug === props.provider.id && c.credentialMode === "oauthbearer"
+  );
 
   const [connecting, setConnecting] = createSignal(false);
   const [deviceCodeData, setDeviceCodeData] = createSignal<{
@@ -273,14 +275,13 @@ const ProviderCard: Component<{
   const [newApiKey, setNewApiKey] = createSignal("");
   const [apiKeyError, setApiKeyError] = createSignal("");
 
-  // OAuth poll cancellation state.
-  const pollState: { timerId: ReturnType<typeof setTimeout> | null; cancelled: boolean } = {
+  const pollState: { timerId: ReturnType<typeof setTimeout> | null; generation: number } = {
     timerId: null,
-    cancelled: false,
+    generation: 0,
   };
 
   const cancelOAuthPoll = () => {
-    pollState.cancelled = true;
+    pollState.generation++;
     if (pollState.timerId !== null) {
       clearTimeout(pollState.timerId);
       pollState.timerId = null;
@@ -327,12 +328,13 @@ const ProviderCard: Component<{
   };
 
   const handleConnect = async () => {
-    pollState.cancelled = false;
+    cancelOAuthPoll();
+    const generation = pollState.generation;
     setConnecting(true);
     setConnectError("");
     try {
       const start = await startProviderOAuth(props.provider.id);
-      if (pollState.cancelled) return;
+      if (generation !== pollState.generation) return;
       setDeviceCodeData({
         deviceCode: start.deviceCode,
         verificationUri: start.verificationUri,
@@ -345,7 +347,7 @@ const ProviderCard: Component<{
       let attempts = 0;
       const maxAttempts = Math.ceil(start.expiresInSecs / start.intervalSecs);
       const poll = async () => {
-        if (pollState.cancelled) return;
+        if (generation !== pollState.generation) return;
         if (attempts >= maxAttempts) {
           setConnectError("Device code expired. Please try again.");
           setDeviceCodeData(null);
@@ -357,14 +359,16 @@ const ProviderCard: Component<{
         setPollAttempts(attempts);
         try {
           await pollProviderOAuth(props.provider.id, start.deviceCode);
-          if (pollState.cancelled) return;
+          if (generation !== pollState.generation) return;
           await refreshAuthStatus(props.provider.id);
+          if (generation !== pollState.generation) return;
           await mgmt.refreshCredentials();
+          if (generation !== pollState.generation) return;
           setDeviceCodeData(null);
           setPollAttempts(0);
           setConnecting(false);
         } catch (e) {
-          if (pollState.cancelled) return;
+          if (generation !== pollState.generation) return;
           const errMsg = String(e);
           if (errMsg.includes("authorization pending") || errMsg.includes("polling too fast")) {
             pollState.timerId = setTimeout(poll, start.intervalSecs * 1000);
@@ -378,7 +382,7 @@ const ProviderCard: Component<{
       };
       pollState.timerId = setTimeout(poll, start.intervalSecs * 1000);
     } catch (e) {
-      if (!pollState.cancelled) {
+      if (generation === pollState.generation) {
         setConnectError(String(e));
         setPollAttempts(0);
         setConnecting(false);
@@ -519,9 +523,11 @@ const ProviderCard: Component<{
       <Show when={meta()?.auth !== "api_key"}>
         <div class="space-y-2">
           <Show when={!deviceCodeData() && !connecting()}>
-            <Show when={auth()?.status === "connectedOAuth"}>
+            <Show when={hasOAuth()}>
               <div class="flex items-center justify-between">
-                <span class="text-xs text-success">Connected via OAuth</span>
+                <span class="text-xs text-success">
+                  {auth()?.status === "connectedOAuth" ? "Connected via OAuth" : "OAuth credential stored"}
+                </span>
                 <button
                   onClick={handleDisconnect}
                   class="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs bg-bg-elevated text-text-secondary hover:bg-bg-hover transition-colors"
@@ -531,7 +537,7 @@ const ProviderCard: Component<{
                 </button>
               </div>
             </Show>
-            <Show when={!auth()?.status || auth()?.status === "notConfigured"}>
+            <Show when={!hasOAuth() && (!auth()?.status || auth()?.status === "notConfigured" || auth()?.status === "configuredApiKey")}>
               <button
                 onClick={handleConnect}
                 class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-accent text-void hover:bg-accent-hover transition-colors"

--- a/src/context/ConfigManagementContext.tsx
+++ b/src/context/ConfigManagementContext.tsx
@@ -1,0 +1,267 @@
+import {
+  createContext,
+  useContext,
+  createSignal,
+  onMount,
+  type Component,
+  type JSX,
+} from "solid-js";
+import {
+  listProfiles,
+  saveProfile,
+  deleteProfile,
+  profileImpact,
+  listPrompts,
+  createPrompt,
+  savePrompt,
+  renamePrompt,
+  deletePrompt,
+  promptImpact,
+  listCredentials,
+  setApiKey,
+  deleteCredential,
+  restoreDefaultProfiles,
+  getSharedConfigError,
+  type ManagedProfileRecordDto,
+  type ManagedPromptRecordDto,
+  type CredentialSummaryDto,
+  type DependencyImpactReportDto,
+  type AgentProfileDto,
+  type StoredPromptDto,
+  type CreatePromptInput,
+  type SeedReportDto,
+  type MutationErrorDto,
+  parseMutationError,
+} from "@lib/tauri/config-commands";
+
+export type { MutationErrorDto };
+
+export class MutationError extends Error {
+  dto: MutationErrorDto;
+  constructor(dto: MutationErrorDto) {
+    super(dto.message);
+    this.dto = dto;
+  }
+}
+
+export interface ConfigManagementContextValue {
+  profiles: () => ManagedProfileRecordDto[];
+  prompts: () => ManagedPromptRecordDto[];
+  credentials: () => CredentialSummaryDto[];
+  loading: () => boolean;
+  error: () => string | null;
+  profileError: () => string | null;
+  promptError: () => string | null;
+  credentialError: () => string | null;
+  configInitError: () => string | null;
+  zeroProfiles: () => boolean;
+  refresh: () => Promise<void>;
+  refreshProfiles: () => Promise<void>;
+  refreshPrompts: () => Promise<void>;
+  refreshCredentials: () => Promise<void>;
+
+  saveProfile: (id: string, profile: AgentProfileDto) => Promise<void>;
+  deleteProfile: (id: string) => Promise<void>;
+  profileImpact: (profileId: string) => Promise<DependencyImpactReportDto>;
+
+  createPrompt: (input: CreatePromptInput) => Promise<[string, StoredPromptDto]>;
+  savePrompt: (id: string, prompt: StoredPromptDto) => Promise<void>;
+  renamePrompt: (id: string, newDisplayName: string) => Promise<void>;
+  deletePrompt: (id: string) => Promise<void>;
+  promptImpact: (promptId: string) => Promise<DependencyImpactReportDto>;
+
+  setApiKey: (providerSlug: string, apiKey: string) => Promise<void>;
+  deleteCredential: (providerSlug: string) => Promise<void>;
+
+  restoreDefaults: () => Promise<SeedReportDto>;
+}
+
+const ConfigManagementContext = createContext<ConfigManagementContextValue>();
+
+export const ConfigManagementProvider: Component<{ children: JSX.Element }> = (props) => {
+  const [profiles, setProfiles] = createSignal<ManagedProfileRecordDto[]>([]);
+  const [prompts, setPrompts] = createSignal<ManagedPromptRecordDto[]>([]);
+  const [credentials, setCredentials] = createSignal<CredentialSummaryDto[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [profileError, setProfileError] = createSignal<string | null>(null);
+  const [promptError, setPromptError] = createSignal<string | null>(null);
+  const [credentialError, setCredentialError] = createSignal<string | null>(null);
+  const [configInitError, setConfigInitError] = createSignal<string | null>(null);
+
+  const error = () => profileError() ?? promptError() ?? credentialError() ?? configInitError();
+
+  const zeroProfiles = () => {
+    if (loading()) return false;
+    if (configInitError()) return false;
+    if (profileError()) return false;
+    const records = profiles();
+    return (
+      records.length === 0 ||
+      !records.some((r) => r.status === "ready")
+    );
+  };
+
+  const refreshProfiles = async () => {
+    try {
+      const result = await listProfiles();
+      setProfiles(result);
+      setProfileError(null);
+    } catch (e) {
+      const msg = typeof e === "string" ? e : String(e);
+      setProfileError(msg);
+      throw e;
+    }
+  };
+
+  const refreshPrompts = async () => {
+    try {
+      const result = await listPrompts();
+      setPrompts(result);
+      setPromptError(null);
+    } catch (e) {
+      const msg = typeof e === "string" ? e : String(e);
+      setPromptError(msg);
+      throw e;
+    }
+  };
+
+  const refreshCredentials = async () => {
+    try {
+      const result = await listCredentials();
+      setCredentials(result);
+      setCredentialError(null);
+    } catch (e) {
+      const msg = typeof e === "string" ? e : String(e);
+      setCredentialError(msg);
+      throw e;
+    }
+  };
+
+  const refresh = async () => {
+    setLoading(true);
+    setProfileError(null);
+    setPromptError(null);
+    setCredentialError(null);
+
+    // Check for shared config initialization error first.
+    try {
+      const initError = await getSharedConfigError();
+      if (initError) {
+        setConfigInitError(initError);
+        setLoading(false);
+        return;
+      }
+      setConfigInitError(null);
+    } catch (e) {
+      const message = typeof e === "string" ? e : String(e);
+      setConfigInitError(`Unable to verify shared configuration: ${message}`);
+      setLoading(false);
+      return;
+    }
+
+    // Load each resource independently so a failure in one does not
+    // suppress others.
+    await Promise.allSettled([
+      refreshProfiles(),
+      refreshPrompts(),
+      refreshCredentials(),
+    ]);
+
+    setLoading(false);
+  };
+
+  onMount(() => {
+    refresh();
+  });
+
+  const wrapMutation = async (mutation: () => Promise<void>, refreshFn: () => Promise<void>) => {
+    try {
+      await mutation();
+    } catch (e) {
+      throw new MutationError(parseMutationError(e));
+    }
+    // Refresh after successful mutation. If refresh fails, the per-resource
+    // error signal is set but the mutation itself succeeded.
+    try {
+      await refreshFn();
+    } catch {
+      // Error already captured in the per-resource signal.
+    }
+  };
+
+  const value: ConfigManagementContextValue = {
+    profiles,
+    prompts,
+    credentials,
+    loading,
+    error,
+    profileError,
+    promptError,
+    credentialError,
+    configInitError,
+    zeroProfiles,
+    refresh,
+    refreshProfiles,
+    refreshPrompts,
+    refreshCredentials,
+
+    saveProfile: (id, profile) =>
+      wrapMutation(() => saveProfile(id, profile), refreshProfiles),
+    deleteProfile: (id) =>
+      wrapMutation(() => deleteProfile(id), refreshProfiles),
+    profileImpact: async (profileId) => {
+      return profileImpact(profileId);
+    },
+
+    createPrompt: async (input) => {
+      try {
+        const result = await createPrompt(input);
+        try {
+          await refreshPrompts();
+        } catch {
+          // Error already captured.
+        }
+        return result;
+      } catch (e) {
+        throw new MutationError(parseMutationError(e));
+      }
+    },
+    savePrompt: (id, prompt) =>
+      wrapMutation(() => savePrompt(id, prompt), refreshPrompts),
+    renamePrompt: (id, newDisplayName) =>
+      wrapMutation(() => renamePrompt(id, newDisplayName), refreshPrompts),
+    deletePrompt: (id) =>
+      wrapMutation(() => deletePrompt(id), refreshPrompts),
+    promptImpact: async (promptId) => {
+      return promptImpact(promptId);
+    },
+
+    setApiKey: (providerSlug, apiKey) =>
+      wrapMutation(async () => { await setApiKey(providerSlug, apiKey); }, refreshCredentials),
+    deleteCredential: (providerSlug) =>
+      wrapMutation(() => deleteCredential(providerSlug), refreshCredentials),
+
+    restoreDefaults: async () => {
+      const report = await restoreDefaultProfiles();
+      try {
+        await refreshProfiles();
+      } catch {
+        // Error already captured.
+      }
+      return report;
+    },
+  };
+
+  return (
+    <ConfigManagementContext.Provider value={value}>
+      {props.children}
+    </ConfigManagementContext.Provider>
+  );
+};
+
+export const useConfigManagement = () => {
+  const ctx = useContext(ConfigManagementContext);
+  if (!ctx)
+    throw new Error("useConfigManagement must be used within ConfigManagementProvider");
+  return ctx;
+};

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -54,7 +54,6 @@ interface SettingsContextValue {
   removeSkillDir: (dir: string) => void;
   updateModelRegistry: () => Promise<void>;
   registryLastUpdated: () => string | null;
-  activeApiKey: () => string;
   apiKeyForProvider: (providerId: string) => string;
   hasConfiguredProvider: () => boolean;
   isProviderConfigured: (providerId: string) => boolean;
@@ -384,7 +383,6 @@ export const SettingsProvider: Component<{ children: JSX.Element }> = (props) =>
       }));
       persistSetting("skills", settings.skills);
     },
-    activeApiKey: () => "",
     apiKeyForProvider: () => "",
     hasConfiguredProvider: () =>
       settings.providers.some((p) => p.enabled && isProviderConfigured(p.id)),

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -7,7 +7,7 @@ import {
   type JSX,
 } from "solid-js";
 import { createStore, produce } from "solid-js/store";
-import { KNOWN_MODELS, DEFAULT_PROVIDERS, parseModelSlug } from "@lib/models";
+import { KNOWN_MODELS, DEFAULT_PROVIDERS } from "@lib/models";
 import { updateModelRegistry as fetchModelRegistry, getProviderAuthStatus, loadSettingsRows, saveSettingRow } from "@lib/tauri/commands";
 import type { AppSettings, ProviderConfig, McpServerConfig, ModelInfo } from "@/types/settings";
 
@@ -245,7 +245,6 @@ export const SettingsProvider: Component<{ children: JSX.Element }> = (props) =>
     const provider = settings.providers.find((p) => p.id === providerId && p.enabled);
     if (!provider) return false;
     if (provider.id === "local") return true;
-    if ((provider.apiKey ?? "").trim().length > 0) return true;
     const auth = authStatuses()[providerId];
     if (auth && (auth.status === "connectedOAuth" || auth.status === "configuredApiKey")) {
       return true;
@@ -385,16 +384,8 @@ export const SettingsProvider: Component<{ children: JSX.Element }> = (props) =>
       }));
       persistSetting("skills", settings.skills);
     },
-    activeApiKey: () => {
-      const all = [...registryModels(), ...KNOWN_MODELS, ...settings.customModels];
-      const { providerId } = parseModelSlug(settings.defaultModel, all);
-      const provider = settings.providers.find((p) => p.id === providerId && p.enabled);
-      return provider?.apiKey ?? "";
-    },
-    apiKeyForProvider: (providerId) => {
-      const provider = settings.providers.find((p) => p.id === providerId && p.enabled);
-      return provider?.apiKey ?? "";
-    },
+    activeApiKey: () => "",
+    apiKeyForProvider: () => "",
     hasConfiguredProvider: () =>
       settings.providers.some((p) => p.enabled && isProviderConfigured(p.id)),
     isProviderConfigured,

--- a/src/context/UIContext.tsx
+++ b/src/context/UIContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, createSignal, type Component, type JSX } from "solid-js";
 
-export type AppView = "chat" | "settings";
+export type AppView = "chat" | "settings" | "agents";
+
+export type AgentsSection = "profiles" | "prompts";
 
 /** Which right-side panel is currently shown (only one at a time). */
 export type RightPane = "mcp" | "tools" | "model" | null;
@@ -12,6 +14,8 @@ interface UIContextValue {
   setQuickLaunchOpen: (open: boolean) => void;
   currentView: () => AppView;
   setCurrentView: (view: AppView) => void;
+  agentsSection: () => AgentsSection;
+  setAgentsSection: (section: AgentsSection) => void;
   rightPane: () => RightPane;
   /** Open the given pane, or close it if it is already open (mutually exclusive). */
   toggleRightPane: (pane: Exclude<RightPane, null>) => void;
@@ -26,6 +30,7 @@ export const UIProvider: Component<{ children: JSX.Element }> = (props) => {
   const [sidebarOpen, setSidebarOpen] = createSignal(true);
   const [quickLaunchOpen, setQuickLaunchOpen] = createSignal(false);
   const [currentView, setCurrentView] = createSignal<AppView>("chat");
+  const [agentsSection, setAgentsSection] = createSignal<AgentsSection>("profiles");
   const [rightPane, setRightPane] = createSignal<RightPane>(null);
 
   const toggleRightPane = (pane: Exclude<RightPane, null>) =>
@@ -39,6 +44,8 @@ export const UIProvider: Component<{ children: JSX.Element }> = (props) => {
     setQuickLaunchOpen,
     currentView,
     setCurrentView,
+    agentsSection,
+    setAgentsSection,
     rightPane,
     toggleRightPane,
     closeRightPane,

--- a/src/lib/tauri/config-commands.ts
+++ b/src/lib/tauri/config-commands.ts
@@ -1,0 +1,217 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// ── Config management commands ──
+
+export interface AgentProfileDto {
+  name: string;
+  kind: "runtimeDefault" | "managed";
+  providerSlug?: string;
+  model?: string;
+  tools: { kind: "inherit" } | { kind: "allow"; names: string[] } | { kind: "deny"; names: string[] };
+  skills: { kind: "none" } | { kind: "allow"; names: string[] } | { kind: "inherit" };
+  approval: "perTool" | "autoApprove";
+  identityPrompt?: string;
+}
+
+export interface ManagedProfileEntryDto {
+  id: string;
+  profile: AgentProfileDto;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RecordDiagnosticDto {
+  category: string;
+  message: string;
+}
+
+export type ManagedProfileRecordDto =
+  | { status: "ready"; entry: ManagedProfileEntryDto }
+  | { status: "needsAttention"; id: string; decoded?: AgentProfileDto; diagnostics: RecordDiagnosticDto[] };
+
+export interface StoredPromptDto {
+  displayName: string;
+  normalizedName: string;
+  instructions: string;
+  skills: string[];
+  profile?: string;
+}
+
+export interface ManagedPromptEntryDto {
+  id: string;
+  prompt: StoredPromptDto;
+  identityState: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type ManagedPromptRecordDto =
+  | { status: "ready"; entry: ManagedPromptEntryDto }
+  | { status: "needsAttention"; id: string; decoded?: StoredPromptDto; diagnostics: RecordDiagnosticDto[] };
+
+export interface CredentialSummaryDto {
+  providerSlug: string;
+  credentialMode: string;
+  authStatus: string;
+  expiresAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type DependencyEntityDto =
+  | { kind: "providerCredential"; slug: string }
+  | { kind: "profile"; id: string }
+  | { kind: "prompt"; id: string }
+  | { kind: "automationTask"; id: string }
+  | { kind: "scheduledTask"; id: string };
+
+export interface DependencyLinkDto {
+  entity: DependencyEntityDto;
+  direction: "depends" | "dependent";
+  proximity: "direct" | "transitive";
+  path: DependencyEntityDto[];
+}
+
+export interface DependencyImpactReportDto {
+  target: DependencyEntityDto;
+  links: DependencyLinkDto[];
+  diagnostics: string[];
+}
+
+export function formatDependencyEntity(entity: DependencyEntityDto): string {
+  switch (entity.kind) {
+    case "providerCredential":
+      return `Provider credential: ${entity.slug}`;
+    case "profile":
+      return `Profile: ${entity.id}`;
+    case "prompt":
+      return `Prompt: ${entity.id}`;
+    case "automationTask":
+      return `Automation task: ${entity.id}`;
+    case "scheduledTask":
+      return `Scheduled task: ${entity.id}`;
+  }
+}
+
+export interface SeedReportDto {
+  policy: string;
+  markerWasPresent: boolean;
+  markerWritten: boolean;
+  created: string[];
+  skippedExisting: string[];
+  diagnostics: string[];
+}
+
+export interface CreatePromptInput {
+  displayName: string;
+  instructions: string;
+  skills: string[];
+  profile?: string;
+}
+
+export interface MutationErrorDto {
+  kind: string;
+  message: string;
+  field?: string;
+  referrers?: string[];
+}
+
+/// Normalize a Tauri rejection value into a MutationErrorDto.
+/// Handles both typed DTO rejections and legacy string errors.
+export function parseMutationError(e: unknown): MutationErrorDto {
+  if (typeof e === "string") {
+    return { kind: "unknown", message: e };
+  }
+  if (e && typeof e === "object") {
+    const obj = e as Record<string, unknown>;
+    if (typeof obj.message === "string") {
+      return {
+        kind: typeof obj.kind === "string" ? obj.kind : "unknown",
+        message: obj.message,
+        field: typeof obj.field === "string" ? obj.field : undefined,
+        referrers: Array.isArray(obj.referrers) ? (obj.referrers as string[]) : undefined,
+      };
+    }
+  }
+  return { kind: "unknown", message: String(e) };
+}
+
+// ── Profile commands ──
+
+export async function listProfiles(): Promise<ManagedProfileRecordDto[]> {
+  return invoke("list_profiles");
+}
+
+export async function getProfile(id: string): Promise<ManagedProfileRecordDto | null> {
+  return invoke("get_profile", { id });
+}
+
+export async function saveProfile(id: string, profile: AgentProfileDto): Promise<void> {
+  return invoke("save_profile", { id, profile });
+}
+
+export async function deleteProfile(id: string): Promise<void> {
+  return invoke("delete_profile", { id });
+}
+
+export async function profileImpact(profileId: string): Promise<DependencyImpactReportDto> {
+  return invoke("profile_impact", { profileId });
+}
+
+// ── Prompt commands ──
+
+export async function listPrompts(): Promise<ManagedPromptRecordDto[]> {
+  return invoke("list_prompts");
+}
+
+export async function getPrompt(id: string): Promise<ManagedPromptRecordDto | null> {
+  return invoke("get_prompt", { id });
+}
+
+export async function createPrompt(input: CreatePromptInput): Promise<[string, StoredPromptDto]> {
+  return invoke("create_prompt", { input });
+}
+
+export async function savePrompt(id: string, prompt: StoredPromptDto): Promise<void> {
+  return invoke("save_prompt", { id, prompt });
+}
+
+export async function renamePrompt(id: string, newDisplayName: string): Promise<void> {
+  return invoke("rename_prompt", { id, newDisplayName });
+}
+
+export async function deletePrompt(id: string): Promise<void> {
+  return invoke("delete_prompt", { id });
+}
+
+export async function promptImpact(promptId: string): Promise<DependencyImpactReportDto> {
+  return invoke("prompt_impact", { promptId });
+}
+
+// ── Credential commands ──
+
+export async function listCredentials(): Promise<CredentialSummaryDto[]> {
+  return invoke("list_credentials");
+}
+
+export async function setApiKey(providerSlug: string, apiKey: string): Promise<CredentialSummaryDto> {
+  return invoke("set_api_key", { providerSlug, apiKey });
+}
+
+export async function deleteCredential(providerSlug: string): Promise<void> {
+  return invoke("delete_credential", { providerSlug });
+}
+
+// ── Seed / recovery commands ──
+
+export async function seedDefaultProfiles(): Promise<SeedReportDto> {
+  return invoke("seed_default_profiles");
+}
+
+export async function restoreDefaultProfiles(): Promise<SeedReportDto> {
+  return invoke("restore_default_profiles");
+}
+
+export async function getSharedConfigError(): Promise<string | null> {
+  return invoke("get_shared_config_error");
+}

--- a/src/lib/tauri/config-commands.ts
+++ b/src/lib/tauri/config-commands.ts
@@ -49,10 +49,21 @@ export type ManagedPromptRecordDto =
   | { status: "ready"; entry: ManagedPromptEntryDto }
   | { status: "needsAttention"; id: string; decoded?: StoredPromptDto; diagnostics: RecordDiagnosticDto[] };
 
+export type CredentialMode = "apikey" | "oauthbearer" | "unsupported";
+export type CredentialAuthStatus =
+  | "configuredApiKey"
+  | "connectedOAuth"
+  | "refreshing"
+  | "expired"
+  | "revoked"
+  | "notConfigured"
+  | "unsupported"
+  | `refreshFailed:${string}`;
+
 export interface CredentialSummaryDto {
   providerSlug: string;
-  credentialMode: string;
-  authStatus: string;
+  credentialMode: CredentialMode;
+  authStatus: CredentialAuthStatus;
   expiresAt?: string;
   createdAt: string;
   updatedAt: string;

--- a/src/test/commands.ts
+++ b/src/test/commands.ts
@@ -1,0 +1,54 @@
+import { vi } from "vitest";
+
+/**
+ * Typed mock for the shared Tauri command module.
+ *
+ * Import `mockCommands` in a test file and override only the commands
+ * that test needs. All command functions default to resolving `undefined`
+ * so unrelated calls do not throw.
+ *
+ * Usage:
+ * ```ts
+ * mockCommands.listProfiles.mockResolvedValue({ ok: true, data: [...] });
+ * mockCommands.saveProfile.mockRejectedValue(new Error("validation"));
+ * ```
+ */
+export const mockCommands = {
+  // Profile commands
+  listProfiles: vi.fn(),
+  getProfile: vi.fn(),
+  saveProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  profileImpact: vi.fn(),
+
+  // Prompt commands
+  listPrompts: vi.fn(),
+  getPrompt: vi.fn(),
+  createPrompt: vi.fn(),
+  savePrompt: vi.fn(),
+  renamePrompt: vi.fn(),
+  deletePrompt: vi.fn(),
+  promptImpact: vi.fn(),
+
+  // Credential commands
+  listCredentials: vi.fn(),
+  setApiKey: vi.fn(),
+  deleteCredential: vi.fn(),
+
+  // Seed / recovery
+  seedDefaultProfiles: vi.fn(),
+  restoreDefaultProfiles: vi.fn(),
+
+  // Settings commands (existing)
+  loadSettingsRows: vi.fn(),
+  saveSettingRow: vi.fn(),
+};
+
+/**
+ * Reset all command mocks between tests.
+ */
+export function resetMockCommands() {
+  for (const key of Object.keys(mockCommands)) {
+    (mockCommands as Record<string, ReturnType<typeof vi.fn>>)[key].mockReset();
+  }
+}

--- a/src/test/commands.ts
+++ b/src/test/commands.ts
@@ -34,6 +34,7 @@ export const mockCommands = {
   listCredentials: vi.fn(),
   setApiKey: vi.fn(),
   deleteCredential: vi.fn(),
+  getSharedConfigError: vi.fn().mockResolvedValue(null),
 
   // Seed / recovery
   seedDefaultProfiles: vi.fn(),
@@ -51,4 +52,5 @@ export function resetMockCommands() {
   for (const key of Object.keys(mockCommands)) {
     (mockCommands as Record<string, ReturnType<typeof vi.fn>>)[key].mockReset();
   }
+  mockCommands.getSharedConfigError.mockResolvedValue(null);
 }

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -1,0 +1,26 @@
+import { type Component, type JSX } from "solid-js";
+import { render } from "@solidjs/testing-library";
+import { mockCommands, resetMockCommands } from "./commands";
+
+/**
+ * Render a Solid component wrapped in the providers it needs for testing.
+ *
+ * The command module is mocked automatically so no real Tauri IPC happens.
+ * Call `resetMockCommands()` in `afterEach` to clear call history.
+ */
+export function renderWithProviders<T extends JSX.Element>(
+  component: () => T,
+  options?: { providers?: Component<{ children: JSX.Element }>[] },
+) {
+  const providers = options?.providers ?? [];
+
+  let tree = component;
+  for (const Provider of [...providers].reverse()) {
+    const current = tree;
+    tree = (() => <Provider>{current() as JSX.Element}</Provider>) as () => T;
+  }
+
+  return render(tree);
+}
+
+export { mockCommands, resetMockCommands };

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -1,6 +1,37 @@
 import { type Component, type JSX } from "solid-js";
 import { render } from "@solidjs/testing-library";
+import { invoke } from "@tauri-apps/api/core";
+import { vi } from "vitest";
 import { mockCommands, resetMockCommands } from "./commands";
+
+function installCommandMocks() {
+  vi.mocked(invoke).mockImplementation((command, args) => {
+    const values = (args ?? {}) as Record<string, unknown>;
+    switch (command) {
+      case "get_shared_config_error": return mockCommands.getSharedConfigError();
+      case "list_profiles": return mockCommands.listProfiles();
+      case "get_profile": return mockCommands.getProfile(values.id);
+      case "save_profile": return mockCommands.saveProfile(values.id, values.profile);
+      case "delete_profile": return mockCommands.deleteProfile(values.id);
+      case "profile_impact": return mockCommands.profileImpact(values.profileId);
+      case "list_prompts": return mockCommands.listPrompts();
+      case "get_prompt": return mockCommands.getPrompt(values.id);
+      case "create_prompt": return mockCommands.createPrompt(values.input);
+      case "save_prompt": return mockCommands.savePrompt(values.id, values.prompt);
+      case "rename_prompt": return mockCommands.renamePrompt(values.id, values.newDisplayName);
+      case "delete_prompt": return mockCommands.deletePrompt(values.id);
+      case "prompt_impact": return mockCommands.promptImpact(values.promptId);
+      case "list_credentials": return mockCommands.listCredentials();
+      case "set_api_key": return mockCommands.setApiKey(values.providerSlug, values.apiKey);
+      case "delete_credential": return mockCommands.deleteCredential(values.providerSlug);
+      case "seed_default_profiles": return mockCommands.seedDefaultProfiles();
+      case "restore_default_profiles": return mockCommands.restoreDefaultProfiles();
+      case "load_settings_rows": return mockCommands.loadSettingsRows();
+      case "save_setting_row": return mockCommands.saveSettingRow(values.key, values.value);
+      default: return Promise.reject(new Error(`Unexpected Tauri command: ${command}`));
+    }
+  });
+}
 
 /**
  * Render a Solid component wrapped in the providers it needs for testing.
@@ -12,6 +43,7 @@ export function renderWithProviders<T extends JSX.Element>(
   component: () => T,
   options?: { providers?: Component<{ children: JSX.Element }>[] },
 ) {
+  installCommandMocks();
   const providers = options?.providers ?? [];
 
   let tree = component;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+// Provide a global mock for @tauri-apps/api/core invoke.
+// Individual tests or test files can override specific commands
+// via vi.mocked(invoke).mockImplementation(...) or the typed
+// command-module mock in ./commands.ts.
+export const invoke = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+}));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -4,7 +4,7 @@ import { vi } from "vitest";
 // Individual tests or test files can override specific commands
 // via vi.mocked(invoke).mockImplementation(...) or the typed
 // command-module mock in ./commands.ts.
-export const invoke = vi.fn();
+const invoke = vi.hoisted(() => vi.fn());
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke,

--- a/src/test/smoke.test.tsx
+++ b/src/test/smoke.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@solidjs/testing-library";
 import { createSignal, type Component } from "solid-js";
+import { mockCommands, renderWithProviders, resetMockCommands } from "./render";
 
 describe("test infrastructure smoke test", () => {
   it("renders a Solid component", () => {
@@ -31,5 +32,15 @@ describe("test infrastructure smoke test", () => {
     const result = await invoke("test_command");
     expect(result).toBe("ok");
     expect(invoke).toHaveBeenCalledWith("test_command");
+  });
+
+  it("wires typed config command mocks", async () => {
+    mockCommands.listProfiles.mockResolvedValue([{ status: "ready" }]);
+    renderWithProviders(() => <div />);
+    const { listProfiles } = await import("@lib/tauri/config-commands");
+
+    await expect(listProfiles()).resolves.toEqual([{ status: "ready" }]);
+    expect(mockCommands.listProfiles).toHaveBeenCalledOnce();
+    resetMockCommands();
   });
 });

--- a/src/test/smoke.test.tsx
+++ b/src/test/smoke.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+import { createSignal, type Component } from "solid-js";
+
+describe("test infrastructure smoke test", () => {
+  it("renders a Solid component", () => {
+    const TestComponent: Component = () => <p data-testid="hello">Hello</p>;
+    const { getByTestId } = render(() => <TestComponent />);
+    expect(getByTestId("hello").textContent).toBe("Hello");
+  });
+
+  it("handles user interaction", async () => {
+    const TestComponent: Component = () => {
+      const [count, setCount] = createSignal(0);
+      return (
+        <button data-testid="btn" onClick={() => setCount(count() + 1)}>
+          Count: {count()}
+        </button>
+      );
+    };
+    const { getByTestId } = render(() => <TestComponent />);
+    const btn = getByTestId("btn");
+    expect(btn.textContent).toBe("Count: 0");
+    fireEvent.click(btn);
+    expect(btn.textContent).toBe("Count: 1");
+  });
+
+  it("mocks Tauri invoke", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockResolvedValue("ok");
+    const result = await invoke("test_command");
+    expect(result).toBe("ok");
+    expect(invoke).toHaveBeenCalledWith("test_command");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+import solid from "vite-plugin-solid";
+import path from "path";
+
+export default defineConfig({
+  plugins: [solid()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+      "@components": path.resolve(__dirname, "src/components"),
+      "@context": path.resolve(__dirname, "src/context"),
+      "@lib": path.resolve(__dirname, "src/lib"),
+    },
+  },
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Summary

- add the Agents workspace with typed profile and stored-prompt CRUD, diagnostics, dependency-aware deletion, and zero-profile recovery
- move provider credentials to secret-safe typed operations with API-key/OAuth status and independent lifecycle handling
- migrate shared configuration ownership and seeding to `iron-core` v0.1.35 from crates.io, including atomic minimum-profile deletion
- add typed dependency impact DTOs, actionable initialization failures, and Solid component-integration test infrastructure
- address CodeRabbit feedback for initialization failures, rename integrity, OAuth polling, accessibility, and test wiring

## Type

- [x] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation only

## Verification

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --locked -- -D warnings`
- [x] `cargo test --locked` (26 passed)
- [x] `pnpm test` (44 passed)
- [x] `tsc --noEmit`
- [x] `pnpm lint` (0 errors; 31 existing Solid reactivity warnings)
- [x] `pnpm build`
- [x] `openspec validate add-config-management-ui --strict`
- [x] CodeRabbit local review (0 findings)

## Checklist

- [x] Changes are covered by automated tests
- [x] User-facing and design documentation is updated
- [x] No persisted credentials or secret values are returned to the frontend
- [x] Local CI-equivalent checks pass

Closes #54
