### PR TITLE
Upgrade to iron-core 0.1.36 to fix the Windows link failure

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3692,9 +3692,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iron-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9a40ada08d45e95e5a2dbdf1537b1827954777c3d0cafe2c8d84a245e388b8"
+checksum = "4b5c63c6a97f0486a3e1151aa0c84df0de8d6d346e2695f5cba63d1ad7b3b69b"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3705,6 +3705,7 @@ dependencies = [
  "directories",
  "extism",
  "futures",
+ "get-size2",
  "globset",
  "grep-regex",
  "grep-searcher",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,8 +19,8 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-iron-core = { version = "0.1.35", features = ["embedded-python"] }
-iron-providers = "0.2.13"
+iron-core = { version = "0.1.36", features = ["embedded-python"] }
+iron-providers = "0.2.14"
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 xcap = "0.9.6"


### PR DESCRIPTION
Two lines in `Cargo.toml` plus the lockfile. `main` currently **does not build on Windows**; this fixes that.

## The problem

iron-core 0.1.35 declared its `scheduled_task` platform adapters unconditionally, so the **launchd** (macOS) adapter compiled on every target and referenced the Unix-only `getuid`:

```
error LNK2019: unresolved external symbol getuid referenced in function
  iron_core::scheduled_task::platform::launchd::extern_uid
agentiron_lib.dll : fatal error LNK1120: 1 unresolved externals
```

Verified against current `main` on `x86_64-pc-windows-msvc`: `cargo build` and `cargo test` both fail this way today.

Two reasons this went unnoticed:

- **`cargo check` does not link**, so it passes cleanly. Only `cargo build`/`cargo test` fail.
- **CI runs on `ubuntu-latest`**, where `getuid` resolves. The break is Windows-only, so CI is green while every Windows build fails.

## The fix

0.1.36 gates the adapters by `target_os`, which is what the module's own docs already claimed ("Each adapter is gated by its target platform"). Reported and fixed upstream as AgentIron/iron-core#102.

`iron-providers` moves 0.2.13 → 0.2.14 to match what iron-core 0.1.36 depends on, so the crate isn't resolved twice — a mismatch there yields two copies and `impl Provider for ProviderConnection` only applies to iron-core's.

## No pin needed here

0.1.36 also carries `get-size2 = "=0.10.1"` in its own manifest. `get-size2` 0.10.2 moved `compact_str` `^0.9` → `^0.10` in a *patch* release, which otherwise makes `embedded-python` unresolvable for any fresh consumer. Since iron-core now enforces it upstream, nothing is needed on our side — `compact_str` still resolves to a single 0.9.1 (verified).

## Verification (`x86_64-pc-windows-msvc`)

| Check | Before (0.1.35) | After (0.1.36) |
|---|---|---|
| `cargo build` | ❌ LNK2019 | ✅ |
| `cargo fmt -- --check` | — | ✅ |
| `cargo clippy -- -D warnings` | — | ✅ |
| `cargo test` | ❌ LNK2019 (link) | ⚠️ links; see below |

**One caveat, please read.** With linking fixed, the test binary now builds but fails to *load* on my Windows machine with `STATUS_ENTRYPOINT_NOT_FOUND` (`0xc0000139`) — a DLL-loader problem, distinct from the link error. I could not attribute this to this change: on `main` the tests never link, so this stage was previously unreachable and there is no before/after to compare. It's unlikely to stem from cfg-gating a macOS module, and `dumpbin /DEPENDENTS` shows only system DLLs. CI runs Ubuntu and will exercise the 26 tests properly there, so **please confirm CI is green rather than taking my local run as evidence**. Worth a separate look at whether Windows test runs work for anyone locally.

Unblocks #55 — the scheduler surface (`ScheduledTask`, `ScheduledTaskInput`, `ScheduleStatus`, `ScheduleHealth`, `ScheduleDiagnostic`) compiles and runs from this crate on Windows once this lands.

Supersedes #65, which was cut from a stale base and duplicated work already merged in #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal components to newer versions for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->