### PR TITLE
fix: do not require capability flags on legacy custom models

### DIFF
--- a/src-tauri/src/core_config.rs
+++ b/src-tauri/src/core_config.rs
@@ -352,6 +352,13 @@ async fn migrate_providers(store: &ConfigStore, conn: &Connection) -> Result<(),
     Ok(())
 }
 
+/// A custom model as the pre-iron-core frontend wrote it.
+///
+/// The capability flags are optional in the TypeScript `ModelInfo` and were
+/// only ever written when the user toggled them, so `JSON.stringify` left them
+/// out entirely for most rows. They must default rather than be required, or
+/// the migration rejects legitimate stored data. `ModelInfoJson` in
+/// `commands::settings` models the same shape and has always defaulted them.
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct LegacyModelInfo {
@@ -360,8 +367,11 @@ struct LegacyModelInfo {
     provider_id: String,
     context_window: Option<u32>,
     output_limit: Option<u32>,
+    #[serde(default)]
     tool_call: bool,
+    #[serde(default)]
     reasoning: bool,
+    #[serde(default)]
     vision: bool,
     cost_input: Option<f64>,
     cost_output: Option<f64>,
@@ -373,8 +383,21 @@ async fn migrate_custom_models(store: &ConfigStore, conn: &Connection) -> Result
         None => return Ok(()),
     };
 
-    let models: Vec<LegacyModelInfo> = serde_json::from_str(&value)
+    // Deserialize entry by entry so one unreadable row cannot abort migration.
+    // Failing here aborts config initialization, which leaves `AppState`
+    // unmanaged and makes every command that needs it fail with an opaque
+    // "state not managed" error -- the whole app becomes unusable over a single
+    // malformed custom model. Skipping the entry loses only that model.
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&value)
         .map_err(|e| format!("Failed to parse legacy custom models: {e}"))?;
+
+    let models = entries.into_iter().filter_map(|entry| {
+        serde_json::from_value::<LegacyModelInfo>(entry.clone())
+            .inspect_err(|e| {
+                eprintln!("Skipping unreadable legacy custom model ({e}): {entry}");
+            })
+            .ok()
+    });
 
     for model in models {
         // Preserve existing core custom model rather than overwriting.
@@ -679,6 +702,51 @@ mod tests {
             .unwrap();
         }
         (conn, temp_dir)
+    }
+
+    /// The pre-iron-core frontend omitted the capability flags whenever the
+    /// user never toggled them, so most stored rows look exactly like this.
+    /// Requiring them aborted migration, which left `AppState` unmanaged and
+    /// took the whole app down with "state not managed" on every command.
+    #[tokio::test]
+    async fn migrates_custom_models_without_capability_flags() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let (legacy_conn, _legacy_temp) = legacy_db_with_settings(&[(
+            "custom_models",
+            r#"[{"id":"alibaba/qwen3.5","name":"alibaba/qwen3.5","providerId":"requesty"}]"#,
+        )]);
+
+        migrate_legacy_settings(&store, &legacy_conn).await.unwrap();
+
+        let model = store
+            .get_custom_model("requesty", "alibaba/qwen3.5")
+            .await
+            .unwrap()
+            .expect("custom model should be migrated");
+        assert_eq!(model.display_name, "alibaba/qwen3.5");
+        assert!(!model.supports_tool_calls);
+        assert!(!model.supports_reasoning);
+        assert!(!model.supports_vision);
+    }
+
+    /// One unreadable entry must not cost the user the rest of the migration,
+    /// nor abort startup.
+    #[tokio::test]
+    async fn skips_unreadable_custom_model_entries() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let (legacy_conn, _legacy_temp) = legacy_db_with_settings(&[(
+            "custom_models",
+            r#"[{"name":"no id here","providerId":"requesty"},
+                {"id":"good/model","name":"Good","providerId":"requesty"}]"#,
+        )]);
+
+        migrate_legacy_settings(&store, &legacy_conn).await.unwrap();
+
+        assert!(store
+            .get_custom_model("requesty", "good/model")
+            .await
+            .unwrap()
+            .is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Providers cannot be configured at all. The Providers screen shows two errors, and they are one cause, not two:

```
Failed to parse legacy custom models: missing field `toolCall` at line 1 column 74

state not managed for field `state` on command `start_provider_oauth`.
You must call `.manage()` before using this command
```

This is **not** an `iron-core` or `iron-providers` defect. Both errors originate here.

### Root cause

`LegacyModelInfo` in `core_config.rs` required `toolCall`, `reasoning` and `vision`. The frontend declares them **optional** on `ModelInfo`, and `JSON.stringify` omits `undefined` keys, so any custom model whose flags were never toggled was persisted without them. A real row from an affected legacy database:

```json
[{"id":"alibaba/qwen3.5","name":"alibaba/qwen3.5","providerId":"requesty"}, ...]
```

Three keys. That first object closes at **column 74** — exactly where serde reports the missing field.

`ModelInfoJson` in `commands::settings` models the same wire shape and has always carried `#[serde(default)]` on these flags. The migration copy never got it, so the two structs disagreed about the same data.

### Why one bad row disables the whole app

The OAuth error is downstream. `AppState` is managed only when config initialization succeeds:

```rust
Ok(config) => { app.manage(state::AppState::new(core_config, debug_enabled)); }
Err(e)     => { *shared_config_error.lock().unwrap() = Some(e); }
```

An aborted migration means it is never managed, so every command taking `State<'_, AppState>` — `start_provider_oauth` among them — fails with Tauri's internal "state not managed" message rather than anything actionable. A single unreadable custom model takes the app down and hides its own cause.

### Changes

1. `#[serde(default)]` on the three capability flags, matching `ModelInfoJson`.
2. Deserialize entry by entry, so an unreadable row costs only that model instead of aborting startup. This follows `migrate_default_model`, which already skips invalid legacy values rather than failing.
3. Two regression tests, one using verbatim JSON from an affected database.

### Note on "fresh install"

This was reported on a fresh install, which is misleading — installing does not clear `%APPDATA%`, so the legacy database survives upgrades and carries the unreadable row with it. A genuinely new machine would not hit this.

## Related Issue

No tracking issue — reported directly while configuring providers on a newly installed build. Happy to file one retroactively.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] New tests added (if applicable)

Two regression tests are added:

- `migrates_custom_models_without_capability_flags` — the reported failure, using verbatim JSON from an affected database, asserting the model migrates with all three flags defaulting to `false`.
- `skips_unreadable_custom_model_entries` — a genuinely malformed entry alongside a good one; the good model still migrates and startup is not aborted.

Verified locally:

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- The exact failing JSON now deserializes, checked against a faithful replica of the struct and its serde attributes, yielding `tool_call: false, reasoning: false, vision: false`

These tests could not be *run* on the machine this was developed on: the harness aborts with `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) before any test executes, an environmental failure that reproduces identically on unmodified `main`. CI is therefore the first genuine execution, and it confirms both:

```
test core_config::tests::migrates_custom_models_without_capability_flags ... ok
test core_config::tests::skips_unreadable_custom_model_entries ... ok
test result: ok. 28 passed; 0 failed
```

28 passed against a 26-test baseline, so both new tests ran rather than being silently skipped.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)

## Follow-up worth considering, not included here

Config initialization failing for *any* reason still leaves `AppState` unmanaged, so any future error in that path will present as the same opaque "state not managed" message across every command. Making `AppState` constructible in a degraded mode, so the UI can surface the real cause, would contain the blast radius of the next bug in that path. That is a larger change than this fix warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
